### PR TITLE
Fix vite build path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,7 @@ export default defineConfig({
   define: {
     'process.env': process.env,
   },
+  build: {
+    outDir: 'build',
+  },
 });


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Docker build was broken because `vite` was building to the `dist` folder, while docker was using the `build` folder. Changed `vite` to build to `build` folder instead of `dist`.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
