### PR TITLE
Fixing scroll in the SQL Console page

### DIFF
--- a/src/components/SQLResultsTable/SQLResultsTable.tsx
+++ b/src/components/SQLResultsTable/SQLResultsTable.tsx
@@ -76,7 +76,7 @@ const renderTable = (result: QueryResult) => {
   }
   let columns = result?.cols.map(col => {
     return {
-      title: col,
+      title: () => <span className="font-bold">{col}</span>,
       key: col,
       dataIndex: col,
       width: '10%',
@@ -96,7 +96,7 @@ const renderTable = (result: QueryResult) => {
   if (columns?.length == 0) {
     columns = [
       {
-        title: 'result',
+        title: () => <span className="font-bold">result</span>,
         key: 'result',
         dataIndex: 'result',
         width: '100%',

--- a/src/routes/SQLConsole/SQLConsole.tsx
+++ b/src/routes/SQLConsole/SQLConsole.tsx
@@ -33,7 +33,7 @@ function SQLConsole() {
   };
 
   return (
-    <>
+    <div className="max-w-[88dvw]">
       <Heading level="h1" className="mb-2">
         Console
       </Heading>
@@ -44,7 +44,7 @@ function SQLConsole() {
         value={specifiedQuery}
       />
       <div className="mt-4">{renderResults()}</div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary of changes

At the moment, if we get a particularly wide result set, it'll overflow and expand the screen indefinitely. This fixes the size.

Also making the column titles in the results page bold, for better visibility.

## Checklist

- [ ] Link to issue this PR refers to: n/a
- [ ] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
