### PR TITLE
Tables route styling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,18 @@
 
 ## Unreleased
 
+- Added responsive styling to the tables page.
+
 ## 2024-01-26 - 0.2.1
 
 - Added type information to the result table.
-- Add "Cancel" and "Save" buttons into ScheduledJobLogs component
-- SQL Scheduler UI improvements
+- Add "Cancel" and "Save" buttons into ScheduledJobLogs component.
+- SQL Scheduler UI improvements.
 
 ## 2024-01-25 - 0.2.0
 
 - Added a cluster overview page with overall cluster stats.
-- Updated navigation to be fully responsive and branded
+- Updated navigation to be fully responsive and branded.
 - Added charts to the cluster overview.
 - Improved formatting in the results table.
 - Added formatting of Arrays and Objects in the results table.
@@ -19,18 +21,18 @@
 
 ## 2024-01-22 - 0.1.2
 
-- Improved SQL Scheduler UI and add tests
+- Improved SQL Scheduler UI and add tests.
 
 ## 2024-01-22 - 0.1.1
 
-- Initial release
-- SQL Page
-- Users Page
-- Enterprise Wrapper for pages which require GC
-- Tables Page
-- Implemented navigation (Ctrl+Up/Ctrl+Down) in the SQL Editor
-- Implemented SQL Scheduler UI
+- Initial release.
+- SQL Page.
+- Users Page.
+- Enterprise Wrapper for pages which require GC.
+- Tables Page.
+- Implemented navigation (Ctrl+Up/Ctrl+Down) in the SQL Editor.
+- Implemented SQL Scheduler UI.
 - Added support for displaying certain types differently in the SQLResultsTable.
-- Added a top bar with a logo
-- Added builds for deploying as npm package
-- Added a status bar and calculating cluster data status
+- Added a top bar with a logo.
+- Added builds for deploying as npm package.
+- Added a status bar and calculating cluster data status.

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -116,7 +116,7 @@ function StatusBar() {
   return (
     <>
       <div
-        className="gap-3 flex leading-tight text-white md:hidden"
+        className="gap-3 flex leading-tight select-none text-white md:hidden"
         onClick={() => setMobileVisible(true)}
       >
         <div>
@@ -127,7 +127,7 @@ function StatusBar() {
           <DownOutlined className="opacity-50 text-xs" />
         </div>
       </div>
-      <div className="hidden gap-8 leading-snug text-white md:flex">
+      <div className="hidden gap-8 leading-snug select-none text-white md:flex">
         <div>
           <div className="opacity-50 text-xs uppercase">Cluster</div>
           <div>{spin(cluster?.name)}</div>

--- a/src/components/StatusBar/index.ts
+++ b/src/components/StatusBar/index.ts
@@ -1,0 +1,3 @@
+import StatusBar from './StatusBar';
+
+export default StatusBar;

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -3,3 +3,5 @@
 // -------------------------------------
 export const SHORT_MESSAGE_NOTIFICATION_DURATION = 7;
 export const LONG_MESSAGE_NOTIFICATION_DURATION = 15;
+
+export const TAILWIND_BREAKPOINT_MD = 768;

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -1,7 +1,7 @@
 import SQLConsole from '../routes/SQLConsole/SQLConsole';
 import Users from '../routes/Users/Users';
 import EnterpriseScreen from '../components/EnterpriseScreen/EnterpriseScreen';
-import Tables from '../routes/Tables/Tables';
+import Tables from '../routes/Tables';
 import { Route } from '../types';
 import ScheduledJobs from '../routes/JobScheduler';
 import Overview from '../routes/Overview/Overview.tsx';
@@ -29,11 +29,7 @@ const routes: Route[] = [
   },
   {
     path: '/tables',
-    element: (
-      <div className="p-4">
-        <Tables />
-      </div>
-    ),
+    element: <Tables />,
     label: 'Tables',
     key: 'tables',
   },

--- a/src/routes/Tables/TableDetail.tsx
+++ b/src/routes/Tables/TableDetail.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { LeftOutlined } from '@ant-design/icons';
+import { Button, Heading } from '@crate.io/crate-ui-components';
+import { Table, Tabs, Tag } from 'antd';
+import { useGCContext } from '../../contexts';
+import routes from '../../constants/routes';
+import { format as formatSQL } from 'sql-formatter';
+import {
+  getTableInformation,
+  showCreateTable,
+  TableInfo,
+  TableListEntry,
+} from '../../utils/queries';
+
+function TableDetail({
+  activeTable,
+  setActiveTable,
+  systemSchemas,
+}: {
+  activeTable: TableListEntry | undefined;
+  setActiveTable: (table: TableListEntry | undefined) => void;
+  systemSchemas: string[];
+}) {
+  const { sqlUrl } = useGCContext();
+  const [activeTableInfo, setActiveTableInfo] = useState<TableInfo[] | undefined>();
+  const [createTableSQL, setCreateTableSQL] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!activeTable) {
+      setActiveTableInfo(undefined);
+      return;
+    }
+
+    getTableInformation(
+      sqlUrl,
+      activeTable.table_schema,
+      activeTable.table_name,
+    ).then(setActiveTableInfo);
+
+    setCreateTableSQL(undefined);
+    if (!systemSchemas.includes(activeTable.table_schema)) {
+      showCreateTable(sqlUrl, activeTable.table_schema, activeTable.table_name).then(
+        res => setCreateTableSQL(res ? formatSQL(res) : undefined),
+      );
+    }
+  }, [activeTable]);
+
+  const columns = [
+    {
+      title: '#',
+      key: 'ordinal_position',
+      dataIndex: 'ordinal_position',
+      width: '5%',
+    },
+    {
+      title: 'Name',
+      key: 'column_name',
+      dataIndex: 'column_name',
+      width: '25%',
+      render: (_: string, record: TableInfo) => {
+        return (
+          <span>
+            {record.column_name}{' '}
+            {record.constraint_type ? <Tag>{record.constraint_type}</Tag> : null}
+          </span>
+        );
+      },
+    },
+    {
+      title: 'Type',
+      key: 'data_type',
+      dataIndex: 'data_type',
+      width: '70%',
+      render: (dataType: string) => {
+        return <span>{dataType.toUpperCase()}</span>;
+      },
+    },
+  ];
+
+  const tabs = [
+    {
+      key: 'columns',
+      label: 'Columns',
+      children: (
+        <Table
+          columns={columns}
+          dataSource={activeTableInfo}
+          rowKey="ordinal_position"
+          pagination={false}
+        />
+      ),
+    },
+  ];
+
+  if (createTableSQL) {
+    tabs.push({
+      key: 'SQL',
+      label: 'SQL',
+      children: (
+        <div className="">
+          <pre>{createTableSQL}</pre>
+        </div>
+      ),
+    });
+  }
+
+  return (
+    <div>
+      {activeTable && (
+        <>
+          <div
+            className="block text-crate-blue md:hidden"
+            onClick={() => setActiveTable(undefined)}
+          >
+            <LeftOutlined className="text-xs" /> Back to list
+          </div>
+          <Heading level="h2">
+            {activeTable.table_schema}.{activeTable.table_name}
+          </Heading>
+          <Tabs defaultActiveKey="columns" items={tabs} />
+          <div className="mt-4">
+            <Link
+              to={{
+                pathname: routes.find(r => r.key == 'sql')?.path,
+                search: `?q=SELECT * FROM "${activeTable.table_schema}"."${activeTable.table_name}" LIMIT 100;`,
+              }}
+            >
+              <Button kind="primary">Query</Button>
+            </Link>
+          </div>
+        </>
+      )}
+      {!activeTable && <div>No table selected</div>}
+    </div>
+  );
+}
+
+export default TableDetail;

--- a/src/routes/Tables/TableList.tsx
+++ b/src/routes/Tables/TableList.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react';
+import { StatusLight } from '@crate.io/crate-ui-components';
+import { Spin } from 'antd';
+import {
+  CaretDownOutlined,
+  CaretRightOutlined,
+  CloseOutlined,
+} from '@ant-design/icons';
+import prettyBytes from 'pretty-bytes';
+import { useGCContext } from '../../contexts';
+import { TableListEntry } from '../../utils/queries';
+import { formatHumanReadable } from '../../utils/numbers.ts';
+import {
+  useGetShards,
+  useGetTables,
+  useGetAllocations,
+} from '../../hooks/swrHooks.ts';
+import {
+  tablesWithMissingPrimaryReplicas,
+  tablesWithUnassignedShards,
+} from '../../utils/statusChecks.ts';
+
+function TableList({
+  setActiveTable,
+  systemSchemas,
+}: {
+  setActiveTable: (table: TableListEntry | undefined) => void;
+  systemSchemas: string[];
+}) {
+  const { sqlUrl } = useGCContext();
+  const [expandedSchemas, setExpandedSchemas] = useState<string[] | undefined>();
+  const [schemas, setSchemas] = useState<string[]>([]);
+  const [filter, setFilter] = useState<string>('');
+  const [filterFocused, setFilterFocused] = useState<boolean>(false);
+  const { data: tables } = useGetTables(sqlUrl);
+  const { data: shards } = useGetShards(sqlUrl);
+  const { data: allocations } = useGetAllocations(sqlUrl);
+  const missingReplicasTables = tablesWithMissingPrimaryReplicas(allocations);
+  const unassignedShardTables = tablesWithUnassignedShards(allocations);
+
+  // create a list of schema names
+  useEffect(() => {
+    if (!tables) {
+      return;
+    }
+
+    const schemaNames: string[] = Array.from(
+      new Set(tables?.map(t => t.table_schema)),
+    );
+    setSchemas(schemaNames);
+    if (expandedSchemas === undefined) {
+      setExpandedSchemas([schemaNames[0]]);
+    }
+  }, [tables]);
+
+  const expandCollapseAll = () => {
+    if (expandedSchemas?.length === schemas.length) {
+      setExpandedSchemas([]);
+    } else {
+      setExpandedSchemas(schemas);
+    }
+  };
+
+  const expandCollapseSingle = (schema: string): void => {
+    if (expandedSchemas?.includes(schema)) {
+      setExpandedSchemas(expandedSchemas?.filter(s => s !== schema));
+    } else {
+      setExpandedSchemas([...(expandedSchemas ?? []), schema]);
+    }
+  };
+
+  const getTableSize = (table: TableListEntry) => {
+    const tableShards = shards?.filter(
+      shard =>
+        shard.schema_name == table.table_schema &&
+        shard.table_name == table.table_name &&
+        shard.primary,
+    );
+    if (!tableShards || tableShards.length == 0) {
+      return null;
+    }
+
+    return tableShards
+      .map(shard => {
+        return {
+          records: shard.total_docs,
+          bytes: shard.size_bytes,
+        };
+      })
+      .reduce((prev, current) => {
+        return {
+          records: prev.records + current.records,
+          bytes: prev.bytes + current.bytes,
+        };
+      });
+  };
+
+  const renderSchemaBadge = (schema: string) => {
+    if (systemSchemas.includes(schema)) {
+      return <span className="text-white text-xs uppercase">system</span>;
+    }
+
+    if (missingReplicasTables.filter(t => t.schema_name == schema).length > 0) {
+      return (
+        <StatusLight
+          color={StatusLight.colors.RED}
+          message=""
+          tooltip="Has tables with missing data"
+        />
+      );
+    }
+
+    if (unassignedShardTables.filter(s => s.schema_name == schema).length > 0) {
+      return (
+        <StatusLight
+          color={StatusLight.colors.YELLOW}
+          message=""
+          tooltip="Has underreplicated tables"
+        />
+      );
+    }
+
+    return <StatusLight color={StatusLight.colors.GREEN} message="" />;
+  };
+
+  const renderSchemaList = () => {
+    const output = schemas
+      ?.map(schema => ({
+        name: schema,
+        tables: tables
+          ?.filter(
+            table =>
+              table.table_schema === schema &&
+              table.table_name.toLowerCase().includes(filter.toLowerCase()),
+          )
+          .map(table => table),
+      }))
+      .filter(schema => schema.tables && schema.tables.length > 0);
+
+    if (output.length === 0) {
+      return (
+        <div className="bg-neutral-400 py-8 text-center text-neutral-800">
+          No tables found
+        </div>
+      );
+    }
+
+    return output.map(schema => (
+      <div key={schema.name}>
+        <div
+          className="border-b border-b-[#0083a3]/50 border-l-4 border-l-[#0083a3] cursor-pointer flex group justify-between px-2 py-2.5 hover:bg-[#0083a3] hover:border-l-[#00728f]"
+          onClick={() => expandCollapseSingle(schema.name)}
+        >
+          <div className="flex gap-2 items-center text-white">
+            {expandedSchemas?.includes(schema.name) ? (
+              <CaretDownOutlined className="opacity-40 h-3 w-3 group-hover:opacity-100" />
+            ) : (
+              <CaretRightOutlined className="opacity-40 h-3 w-3 group-hover:opacity-100" />
+            )}
+            <div className="flex gap-1">
+              <span>{schema.name}</span>
+              <span className="bg-[#00627a] min-w-6 ml-1 opacity-60 px-1 py-0.5 rounded-xl text-center text-xs group-hover:opacity-100">
+                {schema.tables?.length}
+              </span>
+            </div>
+          </div>
+          <div className="opacity-80 group-hover:opacity-100">
+            {renderSchemaBadge(schema.name)}
+          </div>
+        </div>
+        {expandedSchemas?.includes(schema.name) && (
+          <div className="bg-[#005266]">
+            {schema.tables?.map(table => renderTable(table))}
+          </div>
+        )}
+      </div>
+    ));
+  };
+
+  const renderTable = (table: TableListEntry) => {
+    const size = getTableSize(table);
+
+    return (
+      <div
+        className="border-b border-b-white/10 border-l-4 border-l-[#004152] cursor-pointer group pl-8 pr-2 py-2 hover:bg-[#004152] hover:border-b-white/20 hover:border-l-[#00313d]"
+        onClick={() => setActiveTable(table)}
+        key={table.table_name}
+      >
+        <div className="flex items-center justify-between text-white/80 group-hover:text-white">
+          <span>{table.table_name}</span>
+          {renderTableBadge(table)}
+        </div>
+        {size && (
+          <>
+            <div className="text-xs text-white/80 group-hover:text-white">
+              {formatHumanReadable(size.records)}{' '}
+              {size.records !== 1 ? 'Records' : 'Record'} ({prettyBytes(size.bytes)})
+            </div>
+            <div className="text-xs text-white/80 group-hover:text-white">
+              {table.number_of_shards} shards / {table.number_of_replicas} replicas
+            </div>
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const renderTableBadge = (table: TableListEntry) => {
+    if (
+      missingReplicasTables.filter(
+        t => t.schema_name == table.table_schema && t.table_name == table.table_name,
+      ).length > 0
+    ) {
+      return (
+        <StatusLight
+          color={StatusLight.colors.RED}
+          message=""
+          tooltip="Table has missing data"
+        />
+      );
+    }
+
+    if (
+      unassignedShardTables.filter(
+        s => s.schema_name == table.table_schema && s.table_name == table.table_name,
+      ).length > 0
+    ) {
+      return (
+        <StatusLight
+          color={StatusLight.colors.YELLOW}
+          message=""
+          tooltip="Table is underreplicated"
+        />
+      );
+    }
+
+    return <StatusLight color={StatusLight.colors.GREEN} message="" />;
+  };
+
+  if (schemas.length === 0) {
+    return <Spin />;
+  }
+  return (
+    <div className="bg-[#d3d3d3] flex flex-col h-full select-none">
+      <div className="bg-white flex h-14 md:border-r md:border-r-neutral-200">
+        <div className="basis-full border-r border-r-neutral-200 p-2">
+          <div
+            className={`border-2 flex gap-2 h-full items-center px-2 rounded-lg ${filterFocused ? 'border-crate-blue' : 'border-neutral-200'}`}
+          >
+            <input
+              placeholder="Filter tables"
+              type="text"
+              className="basis-full outline-none"
+              onChange={event => setFilter(event.target.value)}
+              onFocus={() => setFilterFocused(true)}
+              onBlur={() => setFilterFocused(false)}
+              value={filter}
+            />
+            <button
+              className="aspect-square bg-neutral-300 h-5 outline-none rounded-full text-xs text-white w-5 hover:bg-crate-blue"
+              onClick={() => setFilter('')}
+            >
+              <CloseOutlined />
+            </button>
+          </div>
+        </div>
+        <div
+          className="basis-[40px] cursor-pointer flex group justify-center px-2 hover:bg-[#f8f8f8]"
+          onClick={() => expandCollapseAll()}
+        >
+          {(expandedSchemas?.length || 0) < schemas.length ? (
+            <CaretRightOutlined className="opacity-60 group-hover:opacity-100" />
+          ) : (
+            <CaretDownOutlined className="opacity-60 group-hover:opacity-100" />
+          )}
+        </div>
+      </div>
+      <div className="basis-full overflow-y-auto">
+        <div className="bg-[#0093b8] drop-shadow-xl">{renderSchemaList()}</div>
+      </div>
+    </div>
+  );
+}
+
+export default TableList;

--- a/src/routes/Tables/Tables.tsx
+++ b/src/routes/Tables/Tables.tsx
@@ -1,332 +1,65 @@
 import { useEffect, useState } from 'react';
-import { Button, Heading, StatusLight } from '@crate.io/crate-ui-components';
-import { Collapse, Input, List, Spin, Table, Tabs, Tag } from 'antd';
-import { useGCContext } from '../../contexts';
-import { format as formatSQL } from 'sql-formatter';
-import {
-  getTableInformation,
-  showCreateTable,
-  TableInfo,
-  TableListEntry,
-} from '../../utils/queries';
-import { Link } from 'react-router-dom';
-import routes from '../../constants/routes';
-import prettyBytes from 'pretty-bytes';
-import {
-  useGetShards,
-  useGetTables,
-  useGetAllocations,
-} from '../../hooks/swrHooks.ts';
-import {
-  tablesWithMissingPrimaryReplicas,
-  tablesWithUnassignedShards,
-} from '../../utils/statusChecks.ts';
-import { formatHumanReadable } from '../../utils/numbers.ts';
+import { Heading } from '@crate.io/crate-ui-components';
+import TableDetail from './TableDetail';
+import TableList from './TableList';
+import { TAILWIND_BREAKPOINT_MD } from '../../constants/defaults';
+import { TableListEntry } from '../../utils/queries';
 
 function Tables() {
   const systemSchemas = ['information_schema', 'sys', 'pg_catalog', 'gc'];
-  const { sqlUrl } = useGCContext();
-
-  const [schemas, setSchemas] = useState<string[] | undefined>();
+  const [isMobile, setIsMobile] = useState(false);
   const [activeTable, setActiveTable] = useState<TableListEntry | undefined>();
-  const [activeTableInfo, setActiveTableInfo] = useState<TableInfo[] | undefined>();
-  const [createTableSQL, setCreateTableSQL] = useState<string | undefined>();
-  const [filter, setFilter] = useState<string>('');
 
-  const { data: tables } = useGetTables(sqlUrl);
-  const { data: shards } = useGetShards(sqlUrl);
-  const { data: allocations } = useGetAllocations(sqlUrl);
-  const missingReplicasTables = tablesWithMissingPrimaryReplicas(allocations);
-  const unassignedShardTables = tablesWithUnassignedShards(allocations);
-
+  // get the screen width: we render the components in a different
+  // order depending on the screen width
   useEffect(() => {
-    if (!tables) {
-      return;
-    }
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= TAILWIND_BREAKPOINT_MD);
+    };
 
-    setSchemas(Array.from(new Set(tables?.map(t => t.table_schema))));
-  }, [tables]);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
-  useEffect(() => {
-    setCreateTableSQL(undefined);
-    if (!activeTable) {
-      return;
-    }
-
-    getTableInformation(
-      sqlUrl,
-      activeTable.table_schema,
-      activeTable.table_name,
-    ).then(setActiveTableInfo);
-
-    if (!systemSchemas.includes(activeTable.table_schema)) {
-      showCreateTable(sqlUrl, activeTable.table_schema, activeTable.table_name).then(
-        res => setCreateTableSQL(res ? formatSQL(res) : undefined),
-      );
-    }
-  }, [activeTable]);
-
-  const getTableSize = (schema: string, table: string) => {
-    const tableSizeInfo = shards?.filter(
-      s => s.schema_name == schema && s.table_name == table && s.primary,
-    );
-    if (!tableSizeInfo || tableSizeInfo.length == 0) {
-      return null;
-    }
-
-    return tableSizeInfo
-      .map(rec => {
-        return {
-          records: rec.total_docs,
-          bytes: rec.size_bytes,
-        };
-      })
-      .reduce((prev, current) => {
-        return {
-          records: prev.records + current.records,
-          bytes: prev.bytes + current.bytes,
-        };
-      });
-  };
-
-  const tableBadge = (table: TableListEntry) => {
-    if (
-      missingReplicasTables.filter(
-        t => t.schema_name == table.table_schema && t.table_name == table.table_name,
-      ).length > 0
-    ) {
-      return (
-        <StatusLight
-          color={StatusLight.colors.RED}
-          message=""
-          tooltip="Table has missing data"
-        />
-      );
-    }
-    if (
-      unassignedShardTables.filter(
-        s => s.schema_name == table.table_schema && s.table_name == table.table_name,
-      ).length > 0
-    ) {
-      return (
-        <StatusLight
-          color={StatusLight.colors.YELLOW}
-          message=""
-          tooltip="Table is underreplicated"
-        />
-      );
-    }
-    return <StatusLight color={StatusLight.colors.GREEN} message="" />;
-  };
-
-  const getTableList = (schema: string) => {
-    const schemaTables = tables
-      ?.filter(t => t.table_schema == schema)
-      .filter(t => t.table_name.match(filter));
-
-    if (!schemaTables || schemaTables.length == 0) {
-      return null;
-    }
-
+  // render for mobile
+  if (isMobile) {
     return (
-      <List
-        locale={{ emptyText: 'No tables in this schema' }}
-        bordered
-        dataSource={schemaTables}
-        renderItem={item => {
-          const size = getTableSize(item.table_schema, item.table_name);
-          return (
-            <List.Item
-              className="cursor-pointer"
-              onClick={() => {
-                setActiveTableInfo([]);
-                setActiveTable(item);
-              }}
-            >
-              <div className="flex flex-row justify-between w-60">
-                <div className="grid grid-cols-1">
-                  <div className="font-bold break-words">{item.table_name}</div>
-                  {size && (
-                    <div className="text-xs">
-                      {formatHumanReadable(size.records)} Records (
-                      {prettyBytes(size.bytes)})
-                    </div>
-                  )}
-                  {item.number_of_replicas && (
-                    <div className="text-xs">
-                      {item.number_of_shards} Shards / {item.number_of_replicas}{' '}
-                      Replicas
-                    </div>
-                  )}
-                </div>
-                <div className="ml-8">{tableBadge(item)}</div>
-              </div>
-            </List.Item>
-          );
-        }}
-      />
-    );
-  };
-
-  const schemaBadge = (schema: string) => {
-    if (systemSchemas.includes(schema)) {
-      return <Tag>system</Tag>;
-    }
-    if (missingReplicasTables.filter(t => t.schema_name == schema).length > 0) {
-      return (
-        <StatusLight
-          color={StatusLight.colors.RED}
-          message=""
-          tooltip="Has tables with missing data"
-        />
-      );
-    }
-    if (unassignedShardTables.filter(s => s.schema_name == schema).length > 0) {
-      return (
-        <StatusLight
-          color={StatusLight.colors.YELLOW}
-          message=""
-          tooltip="Has underreplicated tables"
-        />
-      );
-    }
-    return <StatusLight color={StatusLight.colors.GREEN} message="" />;
-  };
-
-  const constraintBadge = (constraint: string | null) => {
-    if (constraint) {
-      return <Tag>{constraint}</Tag>;
-    }
-    return null;
-  };
-
-  const getSchemasSection = () => {
-    const items = schemas
-      ?.map(s => {
-        return {
-          key: s,
-          label: (
-            <div className="flex flex-row justify-between">
-              <div>{s}</div>
-              <div className="ml-4">{schemaBadge(s)}</div>
-            </div>
-          ),
-          children: getTableList(s),
-        };
-      })
-      .filter(i => i);
-
-    return tables ? (
-      <Collapse defaultActiveKey={tables[0].table_schema}>
-        {items
-          ?.filter(i => i.children)
-          .map(item => {
-            return (
-              <Collapse.Panel header={item.label} key={item.key}>
-                {item.children}
-              </Collapse.Panel>
-            );
-          })}
-      </Collapse>
-    ) : (
-      <Spin />
-    );
-  };
-
-  const getActiveTableSection = () => {
-    if (!activeTable) {
-      return null;
-    }
-    const columns = [
-      {
-        title: '#',
-        key: 'ordinal_position',
-        dataIndex: 'ordinal_position',
-        width: '5%',
-      },
-      {
-        title: 'Name',
-        key: 'column_name',
-        dataIndex: 'column_name',
-        width: '25%',
-        render: (_: string, record: TableInfo) => {
-          return (
-            <span>
-              {record.column_name} {constraintBadge(record.constraint_type)}
-            </span>
-          );
-        },
-      },
-      {
-        title: 'Type',
-        key: 'data_type',
-        dataIndex: 'data_type',
-        width: '70%',
-        render: (_: string, record: TableInfo) => {
-          return <span>{record.data_type.toUpperCase()}</span>;
-        },
-      },
-    ];
-
-    const tabs = [
-      {
-        key: `Columns`,
-        label: `Columns`,
-        children: (
-          <Table
-            columns={columns}
-            dataSource={activeTableInfo}
-            rowKey="ordinal_position"
-            pagination={false}
-          />
-        ),
-      },
-    ];
-    if (createTableSQL) {
-      tabs.push({
-        key: 'SQL',
-        label: 'SQL',
-        children: (
-          <div className="">
-            <pre>{createTableSQL}</pre>
-          </div>
-        ),
-      });
-    }
-
-    return (
-      <div>
-        <Heading level="h2">
-          Table: {activeTable?.table_schema}.{activeTable?.table_name}
+      <div className="flex flex-col">
+        <Heading level="h1" className="pt-2 px-2">
+          Tables
         </Heading>
-        <Tabs defaultActiveKey="Columns" items={tabs} />
-        <div className="mt-4">
-          <Link
-            to={{
-              pathname: routes.find(r => r.key == 'sql')?.path,
-              search: `?q=SELECT * FROM "${activeTable.table_schema}"."${activeTable.table_name}" LIMIT 100;`,
-            }}
-          >
-            <Button kind="primary">Query</Button>
-          </Link>
+        <div className={activeTable ? 'hidden' : 'block'}>
+          <TableList setActiveTable={setActiveTable} systemSchemas={systemSchemas} />
+        </div>
+        <div className={activeTable ? 'block pt-4 px-2' : 'hidden'}>
+          <TableDetail
+            activeTable={activeTable}
+            setActiveTable={setActiveTable}
+            systemSchemas={systemSchemas}
+          />
         </div>
       </div>
     );
-  };
+  }
 
+  // render for desktop
   return (
-    <>
-      <Heading level="h1">Tables</Heading>
-      <div className="flex">
-        <div className="border w-1/5 p-4 min-w-80 h-[87vh] overflow-y-scroll">
-          <div className="mb-4">
-            <Input placeholder="Filter" onChange={v => setFilter(v.target.value)} />
-          </div>
-          {getSchemasSection()}
-        </div>
-        <div className="border w-4/5 p-4">{getActiveTableSection()}</div>
+    <div className="flex h-full overflow-hidden">
+      <div className="basis-[370px] h-full">
+        <TableList setActiveTable={setActiveTable} systemSchemas={systemSchemas} />
       </div>
-    </>
+      <div className="basis-full overflow-y-auto p-6">
+        <Heading level="h1">Tables</Heading>
+        <div>
+          <TableDetail
+            activeTable={activeTable}
+            setActiveTable={setActiveTable}
+            systemSchemas={systemSchemas}
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary of changes
Polished the tables route to be more on brand. Responsive, with usage still possible on smaller devices.

Note: there are quite a few inline colors specified here. Will be happy to move these to the tailwind config if the team are happy with them.

## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
