### PR TITLE
Add code component, do not export NotificationHandler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+## 2024-02-01 - 0.4.4
+
+- Added the Code component.
+- Removed the NotificationHandler export.
+
 ## 2024-01-31 - 0.4.3
 
-- Fix close button in QueryStackTraceModal
+- Fix close button in QueryStackTraceModal.
 - Export missing StatusLight components and lookups.
 
 ## 2024-01-31 - 0.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/Code/Code.test.tsx
+++ b/src/components/Code/Code.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '../../../test/testUtils';
+import Code, { CodeProps } from './Code';
+
+const defaultProps: CodeProps = {
+  children: 'example_code',
+};
+
+const setup = (props: Partial<CodeProps> = {}) => {
+  const combinedProps = { ...defaultProps, ...props };
+
+  return render(<Code {...combinedProps} />);
+};
+
+describe('The Code component', () => {
+  it('displays the text passed as value', () => {
+    setup();
+
+    expect(screen.getByText('example_code')).toBeInTheDocument();
+  });
+
+  it('adds any additional classes to the existing display classes', () => {
+    setup({
+      className: 'foo bar',
+      children: 'with custom classes',
+    });
+
+    expect(screen.getByText('with custom classes').classList.contains('foo')).toBe(
+      true,
+    );
+    expect(screen.getByText('with custom classes').classList.contains('bar')).toBe(
+      true,
+    );
+  });
+});

--- a/src/components/Code/Code.tsx
+++ b/src/components/Code/Code.tsx
@@ -1,0 +1,17 @@
+import cx from 'classnames';
+
+export type CodeProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+function Code({ className, children }: CodeProps) {
+  const textClasses = cx(
+    'bg-crate-border-light/50 leading-tight pb-0.5 px-1.5 pt-1 rounded',
+    className,
+  );
+
+  return <code className={textClasses}>{children}</code>;
+}
+
+export default Code;

--- a/src/components/Code/index.ts
+++ b/src/components/Code/index.ts
@@ -1,0 +1,3 @@
+import Code from './Code';
+
+export default Code;

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -26,6 +26,7 @@ describe('the CopyToClipboard component', () => {
 
     expect(screen.getByTestId('copy-to-clipboard-button')).toBeInTheDocument();
   });
+
   describe('when the user clicks the button', () => {
     it('copies the text to the clipboard', async () => {
       const { user } = setup();

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Button, useButtonStyles } from './Button';
 export { default as Checkbox } from './Checkbox';
+export { default as Code } from './Code';
 export { default as ConfirmDelete } from './ConfirmDelete';
 export { default as CopyToClipboard } from './CopyToClipboard';
 export { default as CrateTable } from './CrateTable';
@@ -15,7 +16,7 @@ export { default as InfoModal } from './InfoModal';
 export { default as Layout } from './Layout';
 export { default as Loader } from './Loader';
 export { default as NoDataView } from './NoDataView';
-export { default as NotificationHandler } from './NotificationHandler';
+// export { default as NotificationHandler } from './NotificationHandler';  // do not export, specific to this repo
 export { default as QueryStackTraceModal } from './QueryStackTraceModal';
 export { default as RoundedIcon } from './RoundedIcon';
 export { default as SQLEditor } from './SQLEditor';


### PR DESCRIPTION
## Summary of changes
- Release v0.4.4
- Added the `Code` component.
- Removed the `NotificationHandler` export. Note, I commented this out with a reason why so this problem doesn't happen again (i.e. importing a component into CloudUI which is GCAdmin specific). I am now thinking having two component folders might be safer after all, something like `local` and `shared` with only the items in the `shared` folder being exported.

## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
