### PR TITLE
Allow copying text from JSON tree results view with a double click.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added a node page.
+- Allow copying text from JSON tree results view with a double click.
 
 ## 2024-02-08 - 0.4.6
 

--- a/src/components/SQLResultsTable/JSONTree/JSONTree.tsx
+++ b/src/components/SQLResultsTable/JSONTree/JSONTree.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tree } from 'antd';
+import { Tree, message } from 'antd';
 import { DataNode } from 'antd/lib/tree';
 import TypeAwareValue from '../TypeAwareValue/TypeAwareValue.tsx';
 
@@ -10,6 +10,11 @@ export type JSONTreeParams = {
 const { DirectoryTree } = Tree;
 
 function JSONTree({ json }: JSONTreeParams) {
+  const copyToClipboard = async (value: string) => {
+    message.info({ content: 'Copied!' }, 1);
+    await navigator.clipboard.writeText(value);
+  };
+
   const typeTitle = (
     val: object | object[] | string | number | boolean | undefined,
   ) => {
@@ -56,7 +61,12 @@ function JSONTree({ json }: JSONTreeParams) {
           {k}: <span className="opacity-50">{typeTitle(val)}</span>
         </div>
       ) : (
-        <div key={`${config.path}-${k}-title`}>
+        <div
+          key={`${config.path}-${k}-title`}
+          onDoubleClick={async () => {
+            await copyToClipboard(val);
+          }}
+        >
           {k}: <TypeAwareValue value={val} quoteStrings />
         </div>
       );


### PR DESCRIPTION
## Summary of changes

This was a gap is it was not possible to copy them in any way.

[Screencast from 08-02-24 15:03:31.webm](https://github.com/crate/crate-gc-admin/assets/4594061/da0d2e61-d8e0-4bd6-803e-93788f51b116)



## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
