### PR TITLE
Remember the choice of the output option in the session.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Added a node page.
 - Allow copying text from JSON tree results view with a double click.
 - Fixed error handling in SQL Console.
+- Fixed CSV output
+- Remember the choice of the output option in the session.
 
 ## 2024-02-08 - 0.4.6
 

--- a/src/components/StatsUpdater/StatsUpdater.tsx
+++ b/src/components/StatsUpdater/StatsUpdater.tsx
@@ -12,7 +12,7 @@ function StatsUpdater() {
 
   This is so that we keep updating them in the background
    */
-  const { load, fs_stats } = useSessionStore();
+  const { load, fsStats } = useSessionStore();
   const { data: nodes } = useGetNodeStatus();
   const [previous, setPrevious] = useState<NodeStatusInfo[] | undefined>();
 
@@ -45,7 +45,7 @@ function StatsUpdater() {
 
   const updateFs = (nodes: NodeStatusInfo[]) => {
     nodes.forEach(n => {
-      let stat = fs_stats[n.id];
+      let stat = fsStats[n.id];
       if (!stat) {
         stat = {
           bps_read: 0,
@@ -67,7 +67,7 @@ function StatsUpdater() {
       stat.bps_write =
         (n.fs.total.bytes_written - p.fs.total.bytes_written) / diff_seconds;
       stat.bps_read = (n.fs.total.bytes_read - p.fs.total.bytes_read) / diff_seconds;
-      fs_stats[n.id] = stat;
+      fsStats[n.id] = stat;
     });
   };
 

--- a/src/routes/Nodes/Nodes.tsx
+++ b/src/routes/Nodes/Nodes.tsx
@@ -14,7 +14,7 @@ import useSessionStore from '../../state/session.ts';
 import React from 'react';
 
 function Nodes() {
-  const { fs_stats } = useSessionStore();
+  const { fsStats } = useSessionStore();
 
   const { data: nodes } = useGetNodeStatus();
   const { data: cluster } = useGetCluster();
@@ -236,7 +236,7 @@ function Nodes() {
   };
 
   const renderFS = (node: NodeStatusInfo) => {
-    const stats = fs_stats[node.id];
+    const stats = fsStats[node.id];
     if (!stats) {
       return <GCSpin spinning={true} />;
     }
@@ -254,14 +254,14 @@ function Nodes() {
           <div>{formatNum(stats.iops_read, 0)} iops</div>
           <div>{formatNum(stats.iops_write, 0)} iops</div>
           <div>
-            {prettyBytes(fs_stats[node.id].bps_read, {
+            {prettyBytes(fsStats[node.id].bps_read, {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
             })}
             /s
           </div>
           <div>
-            {prettyBytes(fs_stats[node.id].bps_write, {
+            {prettyBytes(fsStats[node.id].bps_write, {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
             })}

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -19,13 +19,16 @@ type SessionStore = {
     description?: string,
   ) => void;
   load: LoadAverage[];
-  fs_stats: { [key: string]: FSStats };
+  fsStats: { [key: string]: FSStats };
+  tableResultsFormat: string;
+  setTableResultsFormat: (format: string) => void;
 };
 
 const initialState = {
   notification: null,
   load: [],
-  fs_stats: {},
+  fsStats: {},
+  tableResultsFormat: 'pretty',
 };
 
 export type NotificationType = 'error' | 'warn' | 'info';
@@ -42,6 +45,9 @@ const useSessionStore = create<SessionStore>(set => ({
     description?: string,
   ) => {
     set({ notification: { type, message, description } });
+  },
+  setTableResultsFormat: (format: string) => {
+    set({ tableResultsFormat: format });
   },
 }));
 export default useSessionStore;


### PR DESCRIPTION
## Summary of changes

Also fixed a problem with CSV output if we only had one row.

It would break down and not return anything, because the reducer doesn't actually run on arrays with a single element. How fun!


## Checklist

- [ ] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
