### PR TITLE
Bumped nginx to 1.25 to fix CVE-2024-0567.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added cookie name in context.
+- Bumped nginx to 1.25 to fix CVE-2024-0567.
 
 ## 2024-02-13 - 0.5.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH=$PATH:/home/nodeuser/app/node_modules/.bin
 RUN yarn && yarn build && rm -r /home/nodeuser/app/node_modules
 
 # Serve the gc-admin build.
-FROM nginx:1.23
+FROM nginx:1.25.3
 
 # pick up any security updates
 RUN apt-get update && apt-get upgrade -y


### PR DESCRIPTION
## Summary of changes


## Checklist

- [ ] Link to issue this PR refers to:
- [ ] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
