### PR TITLE
Fix Authorization header on GC Api + Prepare release 0.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-02-13 - 0.5.2
+
+- Fix Authorization header on GC Api.
+
 ## 2024-02-13 - 0.5.1
 
 - Added cookie name in context.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/hooks/useGcApi.ts
+++ b/src/hooks/useGcApi.ts
@@ -13,7 +13,7 @@ export default function useGcApi() {
   instance.interceptors.request.use(config => {
     const token = Cookies.get(sessionCookieName);
     if (token) {
-      config.headers.Authorization = `Bearer ${sessionCookieName}`;
+      config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   });


### PR DESCRIPTION
## Summary of changes
This PR fixes a copy-paste error in Authorization header on GC APIs introduced by https://github.com/crate/crate-gc-admin/pull/63 .
It also releases version 0.5.2.

## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
