### PR TITLE
Fixing tab key that conflicts with those used in cloud-ui

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-02-23 - 0.6.3
+
+- Fixing tab key that conflicts with those used in cloud-ui.
+
 ## 2024-02-23 - 0.6.2
 
 - Fixing UI findings on SQL Scheduler.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/routes/JobScheduler/routes/ScheduledJobs.tsx
+++ b/src/routes/JobScheduler/routes/ScheduledJobs.tsx
@@ -8,15 +8,15 @@ export default function ScheduledJobs() {
         {
           children: <ScheduledJobsTable />,
           label: 'Overview',
-          key: 'overview',
+          key: 'scheduled_overview',
         },
         {
           children: <ScheduledJobLogs />,
           label: 'Logs',
-          key: 'logs',
+          key: 'scheduled_logs',
         },
       ]}
-      defaultActiveKey="overview"
+      defaultActiveKey="scheduled_overview"
       destroyInactiveTabPane
     />
   );


### PR DESCRIPTION
## Summary of changes
This also prepare release 0.6.3.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1657
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
