### PR TITLE
Fix create_tag script for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,6 @@
+---
+name: Publish to NPM
+
 on:
   push:
     branches: master
@@ -33,4 +36,4 @@ jobs:
 
       - name: Create tag
         if: steps.check.outputs.changed == 'true'
-        run: ./devtools/create_tag.sh
+        run: echo y | ./devtools/create_tag.sh

--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ and edit your index.css to import library style:
 
 To publish a new version of the `crate-gc-admin` you need to
 
-1.  be part of `@crate.io` organization on npm
-2.  `git checkout -b prefix/release-x.y.z`
-3.  Update `package.json` with the new version
-4.  Update `CHANGES.md` with a new release section
-5.  Commit, push, get approval, merge
-6.  Wait for the GitHub Action to automatically publish the new version on NPM.
+1.  `git checkout -b prefix/release-x.y.z`
+2.  Update `package.json` with the new version
+3.  Update `CHANGES.md` with a new release section
+4.  Commit, push, get approval, merge
+5.  Wait for the GitHub Action to automatically publish the new version on NPM.


### PR DESCRIPTION
## Summary of changes
Publish action works, this just fixes the create_tag script.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1647
- [ ] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
