### PR TITLE
Create tag before publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,12 +28,12 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: yarn build-lib
 
+      - name: Create tag
+        if: steps.check.outputs.changed == 'true'
+        run: echo y | ./devtools/create_tag.sh
+
       - name: Publish to npm
         if: steps.check.outputs.changed == 'true'
         run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create tag
-        if: steps.check.outputs.changed == 'true'
-        run: echo y | ./devtools/create_tag.sh


### PR DESCRIPTION
## Summary of changes
Thanks @SStorm for the suggestion, I have just changed the order and the tag is created before publishing on npm.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1647
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
