### PR TITLE
Handle API rejection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-03-05 - 0.6.13
+
+- Handle case when API requests are rejected by the server.
+
 ## 2024-03-05 - 0.6.12
 
 - Tidied layout issues with the SQL editor.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -47,33 +47,33 @@ const api = async <T>(
     response = axiosError.response!;
   }
 
-  const responseOk = response.status >= 200 && response.status < 300;
+  const responseOk = response && response.status >= 200 && response.status < 300;
 
   // update the output depending on the result of the fetch()
-  const outputData: T | null = response.data || null;
+  const outputData: T | null = response?.data || null;
 
   const output: ApiOutput<T> = {
     success: responseOk,
-    status: response.status,
+    status: response?.status,
     data: outputData,
   };
 
   // do not show a 404 error for invalid invitation tokens
-  if (response.status === 404 && url.includes('/accept-invite/')) {
+  if (response?.status === 404 && url.includes('/accept-invite/')) {
     output.success = false;
     return output;
   }
 
   if (!responseOk && notification) {
-    if (response.status === 404) {
+    if (response?.status === 404) {
       dispatchNotification('error', 'The requested resource was not found. ');
-    } else if (response.status >= 500) {
+    } else if (response?.status >= 500) {
       dispatchNotification(
         'error',
         'An error occurred while accessing the server. Please try again later.',
       );
     } else if (
-      response.status >= 400 &&
+      response?.status >= 400 &&
       output.data &&
       typeof output.data === 'object' &&
       'message' in output.data


### PR DESCRIPTION
## Summary of changes
When deploying a new cluster via the CloudUI, API requests made in the first few seconds to GC can fail. This tiny change handles that scenario.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1589
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
