### PR TITLE
Minor Job Scheduler fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-03-08 - 0.6.14
+
+- Misc minor fixes to Job Scheduler components.
+
 ## 2024-03-05 - 0.6.13
 
 - Handle case when API requests are rejected by the server.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/DisplayDateDifference/DisplayDateDifference.tsx
+++ b/src/components/DisplayDateDifference/DisplayDateDifference.tsx
@@ -48,7 +48,6 @@ export default function DisplayDateDifference({
 
   const difference = timeBetweenDates(start, end);
   if (difference) {
-    console.log(difference);
     const unit = difference.unit;
     const rawValue = difference.value;
     const roundedValue = Math.round(rawValue);

--- a/src/components/SQLEditor/SQLEditor.tsx
+++ b/src/components/SQLEditor/SQLEditor.tsx
@@ -162,7 +162,9 @@ function SQLEditor({
   }, [results]);
 
   useEffect(() => {
-    ace?.getSession().setValue(value || '');
+    if (setShowHistory) {
+      ace?.getSession().setValue(value || '');
+    }
   }, [value]);
 
   const exec = (sql: string | null) => {

--- a/src/routes/JobScheduler/routes/ScheduledJobsCreate.tsx
+++ b/src/routes/JobScheduler/routes/ScheduledJobsCreate.tsx
@@ -1,5 +1,5 @@
 import { ScheduledJobForm } from '../views';
 
-export default function ScheduledJosCreate() {
+export default function ScheduledJobsCreate() {
   return <ScheduledJobForm type="add" />;
 }

--- a/src/routes/JobScheduler/routes/ScheduledJobsEdit.tsx
+++ b/src/routes/JobScheduler/routes/ScheduledJobsEdit.tsx
@@ -3,7 +3,7 @@ import { ScheduledJobForm } from '../views';
 import { useGCGetScheduledJob } from 'hooks/swrHooks';
 import { Loader } from 'components';
 
-export default function ScheduledJosCreate() {
+export default function ScheduledJobsEdit() {
   const { jobId } = useParams();
   const { data: job, isLoading, isValidating } = useGCGetScheduledJob(jobId!);
 

--- a/src/routes/JobScheduler/views/ScheduledJobForm.test.tsx
+++ b/src/routes/JobScheduler/views/ScheduledJobForm.test.tsx
@@ -77,7 +77,7 @@ describe('The "ScheduledJobForm" component', () => {
 
       await user.click(screen.getByText('Cancel'));
 
-      expect(navigateMock).toHaveBeenCalledWith('..');
+      expect(navigateMock).toHaveBeenCalledWith('..', { relative: 'path' });
     });
   });
 
@@ -96,7 +96,7 @@ describe('The "ScheduledJobForm" component', () => {
         expect(createJobSpy).toHaveBeenCalled();
       });
 
-      expect(navigateMock).toHaveBeenCalledWith('..');
+      expect(navigateMock).toHaveBeenCalledWith('..', { relative: 'path' });
     });
   });
 
@@ -147,7 +147,7 @@ describe('The "ScheduledJobForm" component', () => {
           expect(updateJobSpy).toHaveBeenCalled();
         });
 
-        expect(navigateMock).toHaveBeenCalledWith('..');
+        expect(navigateMock).toHaveBeenCalledWith('..', { relative: 'path' });
       });
     });
   });

--- a/src/routes/JobScheduler/views/ScheduledJobForm.tsx
+++ b/src/routes/JobScheduler/views/ScheduledJobForm.tsx
@@ -70,7 +70,7 @@ export default function ScheduledJobForm(props: ScheduledJobFormProps) {
   const errors = form.formState.errors;
 
   const backToJobList = () => {
-    navigate('..');
+    navigate('..', { relative: 'path' });
   };
 
   const onSubmit: SubmitHandler<TForm> = async (data: JobInput) => {
@@ -281,9 +281,7 @@ export default function ScheduledJobForm(props: ScheduledJobFormProps) {
                       onChange={query => {
                         form.setValue('sql', query, { shouldValidate: true });
                       }}
-                      onExecute={() => {
-                        executeQuery();
-                      }}
+                      onExecute={executeQuery}
                       error={errors.sql && errors.sql.message}
                     />
                   </Form.Control>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,7 @@
 export { default as Help } from './Help';
-export { default as JobScheduler } from './JobScheduler';
+export { default as ScheduledJobs } from './JobScheduler/routes/ScheduledJobs';
+export { default as ScheduledJobsCreate } from './JobScheduler/routes/ScheduledJobsCreate';
+export { default as ScheduledJobsEdit } from './JobScheduler/routes/ScheduledJobsEdit';
 export { default as Overview } from './Overview';
 export { default as SQLConsole } from './SQLConsole';
 export { default as Tables } from './Tables';

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -41,6 +41,7 @@ export default defineConfig(({ mode }) => {
           globals: {
             react: 'React',
             'react-dom': 'ReactDOM',
+            'react-router-dom': 'ReactRouterDOM',
           },
         },
       },


### PR DESCRIPTION
## Summary of changes
- missing exports
- a react-router issue when clicking the cancel button from the add scheduled job form took you up to the wrong route within cloudUI
- removed an `onChange` handler that was causing job scheduler SQL editor to be unusable
- a few minor typos

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1681
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
