### PR TITLE
Fixing undefined error on getting job last execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixing undefined error on getting job last execution.
+
 ## 2024-03-12 - 0.6.18
 
 - Display SQL results arrays with 1-based indexing.

--- a/src/hooks/swrHooks.ts
+++ b/src/hooks/swrHooks.ts
@@ -80,13 +80,21 @@ export const useGCGetScheduledJobEnriched = (jobs: Job[]) => {
 
     Promise.all(promises).then(logResults => {
       const newJobs: EnrichedJob[] = jobs.map((job, jobIndex) => {
-        const logs = logResults[jobIndex];
-        const lastLog = logResults[jobIndex]?.filter(log => log.end !== null)[0];
+        const jobLogs = logResults[jobIndex];
+        if (typeof jobLogs === 'undefined') {
+          return {
+            ...job,
+            last_execution: undefined,
+            running: false,
+          };
+        }
+
+        const lastLog = jobLogs.filter(log => log.end !== null)[0];
 
         return {
           ...job,
           last_execution: lastLog,
-          running: logs && logs[0] && logs[0].end === null ? true : false,
+          running: jobLogs && jobLogs[0] && jobLogs[0].end === null ? true : false,
         };
       });
 


### PR DESCRIPTION
## Summary of changes
Fixing [Sentry](https://crate.sentry.io/issues/5069714172/?alert_rule_id=1166365&alert_type=issue&notification_uuid=19520778-b59e-41d8-af35-4948244e4ba3&project=1269418&referrer=slack
) issue (undefined error) on getting job last execution.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1751
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
