### PR TITLE
Switching primary console font to Menlo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Switching main font for console to "Menlo" to improve compatibility with Safari.
+
 ## 2024-03-18 - 0.6.27
 
 - Fixing undefined error on getting job last execution.

--- a/src/components/SQLEditor/SQLEditor.tsx
+++ b/src/components/SQLEditor/SQLEditor.tsx
@@ -320,6 +320,10 @@ function SQLEditor({
           mode="cratedb"
           theme="github"
           fontSize={16}
+          style={{
+            fontFamily:
+              "'Menlo', 'Monaco', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace",
+          }}
           highlightActiveLine
           enableLiveAutocompletion
           editorProps={{ $blockScrolling: true }}


### PR DESCRIPTION
## Summary of changes

The default font "Monaco" seems to be broken on Safari, which makes the console almost unusable on Safari.
This seems to be a known problem, but not fixed so far: https://github.com/ajaxorg/ace/issues/3385#issuecomment-340116579

Therefore I propose to follow the suggestions and switch the default to "Menlo"


https://github.com/crate/crate-gc-admin/assets/23557193/b8646bb3-b701-4538-b2c9-9b4926d54279

![image](https://github.com/crate/crate-gc-admin/assets/23557193/ba1cf495-72e3-46c8-a8f3-81a2e339d07a)


## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
