### PR TITLE
Fix "Pretty" SQL results output unnecessary line breaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix "Pretty" SQL results output unnecessary line breaks.
+
 ## 2024-04-11 - 0.7.0
 
 - Switching main font for console to "Menlo" to improve compatibility with Safari.

--- a/src/components/SQLResults/TypeAwareValue/TypeAwareValue.tsx
+++ b/src/components/SQLResults/TypeAwareValue/TypeAwareValue.tsx
@@ -1,7 +1,7 @@
 import JSONTree from '../JSONTree/JSONTree';
-import wrap from 'word-wrap';
 import { LinkOutlined } from '@ant-design/icons';
 import { ColumnType } from '../../../types/query';
+import { wrapText } from 'utils';
 
 export type TypeAwareValueParams = {
   value: unknown;
@@ -89,9 +89,8 @@ function TypeAwareValue({
     case ColumnType.TEXT:
     case ColumnType.CHARACTER:
     case ColumnType.CHAR:
-      wrapped = wrap(value as string, {
-        width: getWrapSize(totalNumColumns),
-      })?.trim();
+      wrapped = wrapText(value as string, getWrapSize(totalNumColumns));
+
       if (quoteStrings) {
         wrapped = `'${wrapped}'`;
       }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,3 +1,16 @@
+import wrap from 'word-wrap';
+
 export const capitalizeFirstLetter = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export const wrapText = (text: string, wrapSize: number) => {
+  return text
+    .split('\n')
+    .map(line =>
+      wrap(line, {
+        width: wrapSize,
+      }).trim(),
+    )
+    .join('\n');
 };


### PR DESCRIPTION
## Summary of changes
**What is causing the problem**: the library [(word-wrap)](https://www.npmjs.com/package/word-wrap) that wraps the text to a specific length (and creates new lines) is not handling text with multiple lines.

**Fix**: run the wrap library on each line individually instead of on the whole text.

### Before
![image](https://github.com/crate/crate-gc-admin/assets/33689349/696f59f7-4275-4fd0-8dd6-9b924c5558a8)

### After
![image](https://github.com/crate/crate-gc-admin/assets/33689349/04f3a168-d6e1-4f5d-9357-73ef79261037)

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1789
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests. n/a
- [ ] Required Grand Central APIs are already merged. n/a
