### PR TITLE
Improve Nodes page UI/UX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve Nodes page UI/UX.
+
 ## 2024-04-17 - 0.7.1
 
 - Fix "Pretty" SQL results output unnecessary line breaks.

--- a/__mocks__/zustand.ts
+++ b/__mocks__/zustand.ts
@@ -1,0 +1,52 @@
+// __mocks__/zustand.ts
+import * as zustand from 'zustand';
+import { act } from '@testing-library/react';
+
+const { create: actualCreate, createStore: actualCreateStore } =
+  jest.requireActual<typeof zustand>('zustand');
+
+// a variable to hold reset functions for all stores declared in the app
+export const storeResetFns = new Set<() => void>();
+
+const createUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
+  const store = actualCreate(stateCreator);
+  const initialState = store.getInitialState();
+  storeResetFns.add(() => {
+    store.setState(initialState, true);
+  });
+  return store;
+};
+
+// when creating a store, we get its initial state, create a reset function and add it in the set
+export const create = (<T>(stateCreator: zustand.StateCreator<T>) => {
+  // to support curried version of create
+  return typeof stateCreator === 'function'
+    ? createUncurried(stateCreator)
+    : createUncurried;
+}) as typeof zustand.create;
+
+const createStoreUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
+  const store = actualCreateStore(stateCreator);
+  const initialState = store.getInitialState();
+  storeResetFns.add(() => {
+    store.setState(initialState, true);
+  });
+  return store;
+};
+
+// when creating a store, we get its initial state, create a reset function and add it in the set
+export const createStore = (<T>(stateCreator: zustand.StateCreator<T>) => {
+  // to support curried version of createStore
+  return typeof stateCreator === 'function'
+    ? createStoreUncurried(stateCreator)
+    : createStoreUncurried;
+}) as typeof zustand.createStore;
+
+// reset all stores after each test run
+afterEach(() => {
+  act(() => {
+    storeResetFns.forEach(resetFn => {
+      resetFn();
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,7 @@ export default {
     '^.+\\.jsx?$': 'ts-jest',
     '^.+\\.tsx?$': 'ts-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!troublesome-dependency/.*)'],
+  transformIgnorePatterns: ['node_modules/(?!pretty-bytes/.*)'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   globalSetup: './test/global-setup.ts',
 };

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from 'test/testUtils';
 import Chip, { ChipProps } from './Chip';
+import { COLOR_STYLES_MAP } from './ChipConstants';
 
 const defaultProps: ChipProps = {
   children: 'CHIP_CONTENT',
@@ -18,6 +19,14 @@ describe('The Chip component', () => {
     expect(screen.getByText('CHIP_CONTENT')).toBeInTheDocument();
   });
 
+  it('displays a blue chip by default', () => {
+    setup();
+
+    expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+      COLOR_STYLES_MAP[Chip.colors.BLUE],
+    );
+  });
+
   describe('when passing the className', () => {
     it('should render with that className', () => {
       setup({
@@ -25,6 +34,48 @@ describe('The Chip component', () => {
       });
 
       expect(screen.getByText('CHIP_CONTENT')).toHaveClass('bg-pink-500');
+    });
+  });
+
+  describe('Adjusting the chip color', () => {
+    it('can display a gray chip', () => {
+      setup({ color: Chip.colors.GRAY });
+
+      expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+        COLOR_STYLES_MAP[Chip.colors.GRAY],
+      );
+    });
+
+    it('can display a blue chip', () => {
+      setup({ color: Chip.colors.BLUE });
+
+      expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+        COLOR_STYLES_MAP[Chip.colors.BLUE],
+      );
+    });
+
+    it('can display a orange chip', () => {
+      setup({ color: Chip.colors.ORANGE });
+
+      expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+        COLOR_STYLES_MAP[Chip.colors.ORANGE],
+      );
+    });
+
+    it('can display a red chip', () => {
+      setup({ color: Chip.colors.RED });
+
+      expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+        COLOR_STYLES_MAP[Chip.colors.RED],
+      );
+    });
+
+    it('can display a green chip', () => {
+      setup({ color: Chip.colors.GREEN });
+
+      expect(screen.getByText('CHIP_CONTENT')).toHaveClass(
+        COLOR_STYLES_MAP[Chip.colors.GREEN],
+      );
     });
   });
 });

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,15 +1,22 @@
 import { PropsWithChildren } from 'react';
 import { cn } from 'utils';
+import { AVAILABLE_CHIP_COLORS, COLOR_STYLES_MAP } from './ChipConstants';
 
 export type ChipProps = PropsWithChildren<{
+  color?: keyof typeof AVAILABLE_CHIP_COLORS;
   className?: string;
 }>;
 
-export default function Chip({ children, className = '' }: ChipProps) {
+export default function Chip({
+  children,
+  className = '',
+  color = AVAILABLE_CHIP_COLORS.BLUE,
+}: ChipProps) {
   return (
     <span
       className={cn(
-        `inline-flex items-center rounded-md bg-gray-100 p-1 text-[8px] uppercase !leading-3 text-black`,
+        `inline-flex items-center rounded-md p-1 text-[8px] uppercase !leading-3`,
+        COLOR_STYLES_MAP[color],
         className,
       )}
     >
@@ -17,3 +24,5 @@ export default function Chip({ children, className = '' }: ChipProps) {
     </span>
   );
 }
+
+Chip.colors = AVAILABLE_CHIP_COLORS;

--- a/src/components/Chip/ChipConstants.ts
+++ b/src/components/Chip/ChipConstants.ts
@@ -1,0 +1,17 @@
+export const AVAILABLE_CHIP_COLORS = {
+  GRAY: 'GRAY',
+  BLUE: 'BLUE',
+  ORANGE: 'ORANGE',
+  RED: 'RED',
+  GREEN: 'GREEN',
+} as const;
+
+export const COLOR_STYLES_MAP: {
+  [key in keyof typeof AVAILABLE_CHIP_COLORS]: string;
+} = {
+  [AVAILABLE_CHIP_COLORS.GRAY]: 'bg-gray-100 text-black',
+  [AVAILABLE_CHIP_COLORS.BLUE]: 'bg-crate-blue text-white',
+  [AVAILABLE_CHIP_COLORS.ORANGE]: 'bg-orange-400 text-white',
+  [AVAILABLE_CHIP_COLORS.RED]: 'bg-red-600 text-white',
+  [AVAILABLE_CHIP_COLORS.GREEN]: 'bg-green-600 text-white',
+} as const;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -181,7 +181,7 @@ export function DataTable<TData, TValue>({
                     <Table.Head
                       key={header.id}
                       style={{
-                        width: header.column.columnDef.meta
+                        minWidth: header.column.columnDef.meta
                           ? header.column.columnDef.meta.columnWidth
                           : undefined,
                       }}

--- a/src/components/GCSpin/GCSpin.test.tsx
+++ b/src/components/GCSpin/GCSpin.test.tsx
@@ -1,9 +1,18 @@
 import { render, screen } from '../../../test/testUtils';
-import GCSpin from './GCSpin.tsx';
+import GCSpin, { GCSpinParams } from './GCSpin.tsx';
 
-const setup = (spinning: boolean) => {
+const defaultProps: GCSpinParams = {
+  spinning: true,
+};
+
+const setup = (options: Partial<GCSpinParams> = {}) => {
+  const combinedProps = {
+    ...defaultProps,
+    ...options,
+  };
+
   return render(
-    <GCSpin spinning={spinning}>
+    <GCSpin {...combinedProps}>
       <span>Hello world</span>
     </GCSpin>,
   );
@@ -11,16 +20,24 @@ const setup = (spinning: boolean) => {
 
 describe('The GCSpin component', () => {
   it('will render the children if condition is false', () => {
-    setup(false);
+    setup({ spinning: false });
 
     expect(screen.getByText('Hello world')).toBeInTheDocument();
     expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
   });
 
   it('will render a spinner if condition is true', () => {
-    setup(true);
+    setup();
 
     expect(screen.queryByText('Hello world')).not.toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('will use specified test id', () => {
+    setup({
+      spinnedTestId: 'custom-test-id',
+    });
+
+    expect(screen.getByTestId('custom-test-id')).toBeInTheDocument();
   });
 });

--- a/src/components/GCSpin/GCSpin.tsx
+++ b/src/components/GCSpin/GCSpin.tsx
@@ -1,15 +1,16 @@
 import { PropsWithChildren } from 'react';
 import { Spin } from 'antd';
 
-type GCSpinParams = PropsWithChildren<{
+export type GCSpinParams = PropsWithChildren<{
   spinning: boolean;
+  spinnedTestId?: string;
 }>;
 
-function GCSpin({ children, spinning }: GCSpinParams) {
+function GCSpin({ children, spinning, spinnedTestId = 'spinner' }: GCSpinParams) {
   if (!spinning) {
     return children;
   }
-  return <Spin data-testid="spinner" />;
+  return <Spin data-testid={spinnedTestId} />;
 }
 
 export default GCSpin;

--- a/src/components/SQLResults/SQLResultsTable.tsx
+++ b/src/components/SQLResults/SQLResultsTable.tsx
@@ -30,7 +30,9 @@ function SQLResultsTable({ result }: Params) {
       <>
         <div className="flex min-h-12 flex-row items-start justify-between rounded border p-2">
           <div className="flex items-start gap-4 pr-2 text-sm">
-            <Chip className="bg-red-600 uppercase text-white">Error</Chip>
+            <Chip className="uppercase" color={Chip.colors.RED}>
+              Error
+            </Chip>
             <a
               href="https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#error-codes"
               target="_blank"
@@ -298,7 +300,9 @@ function SQLResultsTable({ result }: Params) {
       title={() => (
         <div className="flex h-8 flex-row items-center gap-2">
           <div className="flex items-center gap-2 border-e pr-2 text-xs font-bold">
-            <Chip className="mr-1.5 bg-green-600 text-white">OK</Chip>
+            <Chip className="mr-1.5" color={Chip.colors.GREEN}>
+              OK
+            </Chip>
             {`${result.rowcount} rows, ${result.duration} ms`}
           </div>
           <Radio.Group

--- a/src/components/StatusLight/StatusLight.test.tsx
+++ b/src/components/StatusLight/StatusLight.test.tsx
@@ -38,6 +38,22 @@ describe('The StatusLight component', () => {
         COLOR_STYLES_MAP[StatusLight.colors.RED],
       );
     });
+
+    it('can display a gray light', () => {
+      const { container } = setup({ color: StatusLight.colors.GRAY });
+
+      expect(container.querySelector('circle')).toHaveClass(
+        COLOR_STYLES_MAP[StatusLight.colors.GRAY],
+      );
+    });
+
+    it('can display a blue light', () => {
+      const { container } = setup({ color: StatusLight.colors.BLUE });
+
+      expect(container.querySelector('circle')).toHaveClass(
+        COLOR_STYLES_MAP[StatusLight.colors.BLUE],
+      );
+    });
   });
 
   describe('When displaying a message', () => {
@@ -61,6 +77,16 @@ describe('The StatusLight component', () => {
       const { container } = setup({ color: StatusLight.colors.GREEN, pulse: false });
 
       expect(container.querySelector('animate')).toBeNull();
+    });
+  });
+
+  describe('when the testId prop is passed', () => {
+    it('sets the testId correctly', () => {
+      setup({
+        testId: 'custom-test-id',
+      });
+
+      expect(screen.getByTestId('custom-test-id')).not.toBeNull();
     });
   });
 });

--- a/src/components/StatusLight/StatusLight.tsx
+++ b/src/components/StatusLight/StatusLight.tsx
@@ -6,10 +6,11 @@ import PulsingLight from './PulsingLight';
 import React from 'react';
 
 export type StatusLightProps = {
-  color: string;
+  color: keyof typeof AVAILABLE_LIGHT_COLORS;
   pulse?: boolean;
-  message: React.JSX.Element | string;
+  message?: React.JSX.Element | string;
   tooltip?: React.JSX.Element | string | undefined;
+  testId?: string;
 };
 
 function StatusLight({
@@ -17,11 +18,12 @@ function StatusLight({
   pulse = false,
   message,
   tooltip = undefined,
+  testId,
 }: StatusLightProps) {
   const LightElement = pulse ? PulsingLight : SolidLight;
 
   return (
-    <div>
+    <div data-testid={testId}>
       {tooltip ? (
         <Tooltip
           arrowPointAtCenter
@@ -38,7 +40,7 @@ function StatusLight({
       ) : (
         <LightElement className={COLOR_STYLES_MAP[color]} />
       )}
-      <Text className="ml-1 inline">{message}</Text>
+      {message && <Text className="ml-1 inline">{message}</Text>}
     </div>
   );
 }

--- a/src/components/StatusLight/StatusLightConstants.ts
+++ b/src/components/StatusLight/StatusLightConstants.ts
@@ -3,11 +3,15 @@ export const AVAILABLE_LIGHT_COLORS = {
   YELLOW: 'YELLOW',
   RED: 'RED',
   GRAY: 'GRAY',
-};
+  BLUE: 'BLUE',
+} as const;
 
-export const COLOR_STYLES_MAP = {
+export const COLOR_STYLES_MAP: {
+  [key in keyof typeof AVAILABLE_LIGHT_COLORS]: string;
+} = {
   [AVAILABLE_LIGHT_COLORS.GREEN]: 'fill-green-400',
   [AVAILABLE_LIGHT_COLORS.YELLOW]: 'fill-amber-400',
   [AVAILABLE_LIGHT_COLORS.RED]: 'fill-red-400',
   [AVAILABLE_LIGHT_COLORS.GRAY]: 'fill-neutral-400',
-};
+  [AVAILABLE_LIGHT_COLORS.BLUE]: 'fill-crate-blue',
+} as const;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -65,7 +65,7 @@ const Row = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b transition-colors hover:bg-[#fafafa] data-[state=selected]:bg-slate-100',
+      'border-b transition-colors hover:bg-table-row-hover data-[state=selected]:bg-slate-100',
       className,
     )}
     {...props}
@@ -80,7 +80,7 @@ const Head = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-12 bg-[#fafafa] px-2 text-left align-middle font-medium text-[#737373] [&:has([role=checkbox])]:pr-0',
+      'h-12 bg-table-row-hover px-2 text-left align-middle font-medium text-[#737373] [&:has([role=checkbox])]:pr-0',
       className,
     )}
     {...props}

--- a/src/components/VerticalProgress/VerticalProgress.test.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '../../../test/testUtils';
+import VerticalProgress, {
+  VERTICAL_PROGRESS_BARS,
+  VerticalProgressProps,
+} from './VerticalProgress';
+
+const defaultProps: VerticalProgressProps = {
+  max: 50,
+  current: 10,
+  testId: 'vertical-progress',
+};
+
+const setup = (props: Partial<VerticalProgressProps> = {}) => {
+  const combinedProps = { ...defaultProps, ...props };
+
+  return render(<VerticalProgress {...combinedProps} />);
+};
+
+describe('The VerticalProgress component', () => {
+  it('displays VERTICAL_PROGRESS_BARS bars by default', () => {
+    setup();
+
+    expect(screen.getByTestId('vertical-progress').childNodes).toHaveLength(
+      VERTICAL_PROGRESS_BARS,
+    );
+  });
+
+  it('displays correct number of filled bars', () => {
+    setup();
+
+    const numberOfFilled =
+      (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;
+
+    const wrapper = screen.getByTestId('vertical-progress');
+
+    expect(wrapper.getElementsByClassName('bg-crate-blue')).toHaveLength(
+      numberOfFilled,
+    );
+  });
+
+  it('displays correct number of non-filled bars', () => {
+    setup();
+
+    const numberOfNonFilled =
+      VERTICAL_PROGRESS_BARS -
+      (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;
+
+    const wrapper = screen.getByTestId('vertical-progress');
+
+    expect(wrapper.getElementsByClassName('bg-gray-300')).toHaveLength(
+      numberOfNonFilled,
+    );
+  });
+
+  describe('when the testId prop is passed', () => {
+    it('sets the testId correctly', () => {
+      setup({
+        testId: 'custom-test-id',
+      });
+
+      expect(screen.getByTestId('custom-test-id')).not.toBeNull();
+    });
+  });
+});

--- a/src/components/VerticalProgress/VerticalProgress.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.tsx
@@ -1,19 +1,35 @@
 export type VerticalProgressProps = {
   max: number;
   current: number;
+  testId?: string;
 };
 
-function VerticalProgress({ max, current }: VerticalProgressProps) {
-  const normalized = Math.floor((current / max) * 10);
-  const missing = normalized < 10 ? new Array(10 - normalized).fill('') : [''];
+export const VERTICAL_PROGRESS_BARS = 10;
+
+function VerticalProgress({ max, current, testId }: VerticalProgressProps) {
+  const normalized = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+  const missing =
+    normalized < VERTICAL_PROGRESS_BARS
+      ? new Array(VERTICAL_PROGRESS_BARS - normalized).fill('')
+      : [''];
   const filled = new Array(normalized).fill('');
   return (
-    <div className="h-full">
-      {missing.map(() => {
-        return <div className="mb-0.5 h-[4px] w-full bg-gray-300"></div>;
+    <div className="h-full" data-testid={testId}>
+      {missing.map((_, index) => {
+        return (
+          <div
+            key={`${index}_missing`}
+            className="mb-0.5 h-[4px] w-full bg-gray-300"
+          ></div>
+        );
       })}
-      {filled.map(() => {
-        return <div className="mb-0.5 h-[4px] w-full bg-crate-blue"></div>;
+      {filled.map((_, index) => {
+        return (
+          <div
+            key={`${index}_filled`}
+            className="mb-0.5 h-[4px] w-full bg-crate-blue"
+          ></div>
+        );
       })}
     </div>
   );

--- a/src/components/VerticalProgress/index.ts
+++ b/src/components/VerticalProgress/index.ts
@@ -1,0 +1,3 @@
+import VerticalProgress from './VerticalProgress';
+
+export default VerticalProgress;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -50,3 +50,4 @@ export { default as SyntaxHighlighter } from './SyntaxHighlighter';
 export { default as Table } from './Table';
 export { default as Tree } from './Tree';
 export { default as Text } from './Text';
+export { default as VerticalProgress } from './VerticalProgress';

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -6,3 +6,9 @@ export const SYSTEM_SCHEMAS = ['information_schema', 'sys', 'pg_catalog', 'gc'];
 // - {number}-all
 // - {number}-{number}
 export const SET_REPLICAS_VALUE_REGEXP = /^\d+(-(all|\d+))?$/;
+
+export const NODE_STATUS_THRESHOLD = {
+  CRITICAL: 98,
+  WARNING: 90,
+  GOOD: 0,
+} as const;

--- a/src/constants/queries.ts
+++ b/src/constants/queries.ts
@@ -29,3 +29,56 @@ export const getPartitionedTablesQuery = (includeSystemTables = false) => {
     (tables.number_of_shards IS NOT NULL
     or tables.system) AND partitioned_by IS NOT NULL ${includeSystemTables ? '' : 'AND NOT tables.system'}`;
 };
+
+export const nodesQuery = `SELECT 
+    id, 
+    name, 
+    hostname, 
+    heap, 
+    fs, 
+    load, 
+    version, 
+    process['cpu']['percent'] as cpu_usage, 
+    os_info['available_processors'] as available_processors, 
+    rest_url, 
+    os_info, 
+    now(), 
+    attributes, 
+    mem 
+  FROM 
+    sys.nodes 
+  ORDER BY 
+    name`;
+
+export const clusterInfoQuery = `
+  SELECT 
+    id, 
+    name, 
+    master_node, 
+    settings 
+  FROM 
+    sys.cluster`;
+
+export const shardsQuery = `
+  SELECT
+    table_name,
+    schema_name,
+    node['id'] AS node_id,
+    state,
+    routing_state,
+    relocating_node,
+    count(*) as number_of_shards,
+    "primary",
+    sum(num_docs),
+    avg(num_docs),
+    sum(size)
+  FROM
+    sys.shards
+  GROUP BY
+    table_name,
+    schema_name,
+    node_id,
+    state,
+    routing_state,
+    relocating_node,
+    "primary"`;

--- a/src/hooks/queryHooks.ts
+++ b/src/hooks/queryHooks.ts
@@ -11,7 +11,12 @@ import {
   User,
 } from '../types/cratedb';
 import useExecuteSql from './useExecuteSql';
-import { getPartitionedTablesQuery } from 'constants/queries';
+import {
+  clusterInfoQuery,
+  getPartitionedTablesQuery,
+  nodesQuery,
+  shardsQuery,
+} from 'constants/queries';
 export const useGetUsersQuery = () => {
   const executeSql = useExecuteSql();
 
@@ -66,9 +71,7 @@ export const useGetClusterInfoQuery = () => {
   const executeSql = useExecuteSql();
 
   return async (): Promise<ClusterInfo | undefined> => {
-    const res = await executeSql(
-      'SELECT id, name, master_node, settings FROM sys.cluster',
-    );
+    const res = await executeSql(clusterInfoQuery);
     if (!res.data || Array.isArray(res.data)) {
       return;
     }
@@ -217,10 +220,7 @@ export const useGetNodesQuery = () => {
   const executeSql = useExecuteSql();
 
   const getNodes = async (): Promise<NodeStatusInfo[]> => {
-    const res = await executeSql(
-      "SELECT id, name, hostname, heap, fs, load, version, process['cpu']['percent'] as cpu_usage, " +
-        "os_info['available_processors'] as available_processors, rest_url, os_info, now(), attributes FROM sys.nodes ORDER BY name",
-    );
+    const res = await executeSql(nodesQuery);
 
     if (!res.data || Array.isArray(res.data)) {
       return [];
@@ -241,6 +241,7 @@ export const useGetNodesQuery = () => {
         os_info: r[10],
         timestamp: r[11],
         attributes: r[12],
+        mem: r[13],
       };
     });
   };
@@ -300,30 +301,7 @@ export const useGetShardsQuery = () => {
   const executeSql = useExecuteSql();
 
   const getShards = async (): Promise<ShardInfo[]> => {
-    const res = await executeSql(
-      `SELECT
-              table_name,
-              schema_name,
-              node['id'] AS node_id,
-              state,
-              routing_state,
-              relocating_node,
-              count(*) as number_of_shards,
-              "primary",
-              sum(num_docs),
-              avg(num_docs),
-              sum(size)
-            FROM
-              sys.shards
-            GROUP BY
-              table_name,
-              schema_name,
-              node_id,
-              state,
-              routing_state,
-              relocating_node,
-              "primary"`,
-    );
+    const res = await executeSql(shardsQuery);
 
     if (!res.data || Array.isArray(res.data)) {
       return [];

--- a/src/routes/JobScheduler/views/JobsLogs.tsx
+++ b/src/routes/JobScheduler/views/JobsLogs.tsx
@@ -55,9 +55,7 @@ const getColumnsDefinition = ({
           <div className="flex flex-col">
             <Link to={`./${encodeURIComponent(log.job_id)}`}>{name}</Link>
             <span className="text-[8px]">
-              {isRunning && (
-                <Chip className="bg-orange-400 text-white">RUNNING</Chip>
-              )}
+              {isRunning && <Chip color={Chip.colors.ORANGE}>RUNNING</Chip>}
             </span>
           </div>
         );

--- a/src/routes/JobScheduler/views/JobsTable.tsx
+++ b/src/routes/JobScheduler/views/JobsTable.tsx
@@ -86,7 +86,7 @@ const getColumnsDefinition = ({
           <div className="flex flex-col">
             <Text>{name}</Text>
             <span className="text-[8px]">
-              {running && <Chip className="bg-orange-400 text-white">RUNNING</Chip>}
+              {running && <Chip color={Chip.colors.ORANGE}>RUNNING</Chip>}
             </span>
           </div>
         );

--- a/src/routes/Nodes/Nodes.test.tsx
+++ b/src/routes/Nodes/Nodes.test.tsx
@@ -1,0 +1,450 @@
+import { render, screen } from '../../../test/testUtils';
+import Nodes from '.';
+import { clusterNode } from 'test/__mocks__/nodes';
+import server, { customExecuteQueryResponse } from 'test/msw';
+import { singleNodesQueryResult } from 'test/__mocks__/query';
+import { NodeStatusInfo } from 'types/cratedb';
+import { NODE_STATUS_THRESHOLD } from 'constants/database';
+import prettyBytes from 'pretty-bytes';
+import { VERTICAL_PROGRESS_BARS } from 'components/VerticalProgress/VerticalProgress';
+import { formatNum } from 'utils';
+import { shards } from 'test/__mocks__/shards';
+import useSessionStore from 'src/state/session';
+
+const setup = () => {
+  return render(<Nodes />);
+};
+
+const waitForTableRender = async () => {
+  await screen.findByRole('table');
+};
+
+const { fsStats } = useSessionStore.getState();
+
+const changeStats = (
+  node: NodeStatusInfo,
+  fsUsedPercent: number,
+  heapUsedPercent: number,
+) => {
+  return {
+    ...node,
+    fs: {
+      ...node.fs,
+      total: {
+        ...node.fs.total,
+        used: (fsUsedPercent / 100) * node.fs.total.size,
+      },
+    },
+    heap: {
+      ...node.heap,
+      used: (heapUsedPercent / 100) * node.heap.max,
+    },
+  };
+};
+
+const notMasterNode: NodeStatusInfo = {
+  ...clusterNode,
+  id: 'NOT_MASTER_NODE',
+};
+const unreachableNode: NodeStatusInfo = changeStats(clusterNode, 0, 0);
+const warningNode: NodeStatusInfo = changeStats(
+  clusterNode,
+  NODE_STATUS_THRESHOLD.WARNING + 1,
+  NODE_STATUS_THRESHOLD.WARNING + 1,
+);
+const criticalNode: NodeStatusInfo = changeStats(
+  clusterNode,
+  NODE_STATUS_THRESHOLD.CRITICAL + 1,
+  NODE_STATUS_THRESHOLD.CRITICAL + 1,
+);
+
+describe('The Nodes component', () => {
+  it('renders a loader while loading the nodes', async () => {
+    setup();
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+
+    await waitForTableRender();
+  });
+
+  describe('the "Node" cell', () => {
+    it('shows the node name', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(clusterNode.name)).toBeInTheDocument();
+    });
+
+    it('shows the hostname', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(clusterNode.hostname)).toBeInTheDocument();
+    });
+
+    it('shows CrateDB version', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(`v${clusterNode.version.number}`)).toBeInTheDocument();
+    });
+
+    it('shows cluster specs', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const clusterRam = prettyBytes(clusterNode.mem.free + clusterNode.mem.used, {
+        maximumFractionDigits: 0,
+      });
+
+      expect(
+        screen.getByText(
+          `${clusterNode.os_info.available_processors} CPU Cores | ${clusterRam} RAM`,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows node attributes', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const attributes = Object.keys(clusterNode.attributes);
+
+      expect(attributes.length).toBeGreaterThan(0);
+
+      attributes.forEach(el => {
+        expect(screen.getByText(`${el}: ${clusterNode.attributes[el]}`));
+      });
+
+      expect(screen.getByText(`v${clusterNode.version.number}`)).toBeInTheDocument();
+    });
+
+    describe('the master icon', () => {
+      it('is shown if the node is master', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.getByTestId('master-node')).toBeInTheDocument();
+      });
+
+      it('is not shown if the node is not master', async () => {
+        server.use(
+          customExecuteQueryResponse(singleNodesQueryResult(notMasterNode)),
+        );
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.queryByTestId('master-node')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('the status light', () => {
+      it('shows unreachable status light when node is in unreachable status', async () => {
+        server.use(
+          customExecuteQueryResponse(singleNodesQueryResult(unreachableNode)),
+        );
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.getByTestId('unreachable-node')).toBeInTheDocument();
+      });
+      it('shows the warning status light when node is in warning status', async () => {
+        server.use(customExecuteQueryResponse(singleNodesQueryResult(warningNode)));
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.getByTestId('warning-node')).toBeInTheDocument();
+      });
+
+      it('shows the critical status light when node is in critical status', async () => {
+        server.use(customExecuteQueryResponse(singleNodesQueryResult(criticalNode)));
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.getByTestId('critical-node')).toBeInTheDocument();
+      });
+
+      it('shows the good status light when node is in good status', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.getByTestId('good-node')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('the "Load" cell', () => {
+    it('shows the 1min load', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(formatNum(clusterNode.load[1])!)).toBeInTheDocument();
+    });
+
+    it('shows the 5min load', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(formatNum(clusterNode.load[5])!)).toBeInTheDocument();
+    });
+
+    it('shows the 15min load', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByText(formatNum(clusterNode.load[15])!)).toBeInTheDocument();
+    });
+
+    it('shows the load progress bar', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const max = clusterNode.os_info.available_processors;
+      const current = clusterNode.load[1];
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+
+      expect(screen.getByTestId('load-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('load-progress');
+
+      expect(verticalProgress.getElementsByClassName('bg-crate-blue')).toHaveLength(
+        filled,
+      );
+    });
+  });
+
+  describe('the "Heap Usage" cell', () => {
+    it('shows the used heap', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.heap.used)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the free heap', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.heap.free)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the max heap', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.heap.max)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the heap progress bar', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const max = clusterNode.heap.max;
+      const current = clusterNode.heap.used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+
+      expect(screen.getByTestId('heap-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('heap-progress');
+
+      expect(verticalProgress.getElementsByClassName('bg-crate-blue')).toHaveLength(
+        filled,
+      );
+    });
+  });
+
+  describe('the "Disk" cell', () => {
+    it('shows the used disk', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.fs.total.used)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the available disk', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.fs.total.available)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the disk size', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(
+        screen.getByText(prettyBytes(clusterNode.fs.total.size)),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the disk progress bar', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const max = clusterNode.fs.total.size;
+      const current = clusterNode.fs.total.used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+
+      expect(screen.getByTestId('disk-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('disk-progress');
+
+      expect(verticalProgress.getElementsByClassName('bg-crate-blue')).toHaveLength(
+        filled,
+      );
+    });
+  });
+
+  describe('the "Disk operations" cell', () => {
+    it('renders a loader initially', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      expect(screen.getByTestId('loading-fs')).toBeInTheDocument();
+    });
+
+    describe('after updating the stats', () => {
+      const stats = {
+        iops_write: 10,
+        iops_read: 5,
+        bps_write: 20,
+        bps_read: 25,
+      };
+      beforeAll(() => {
+        fsStats[clusterNode.id] = stats;
+      });
+
+      it('shows reads iops', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.queryByTestId('loading-fs')).not.toBeInTheDocument();
+
+        expect(screen.getByText(`${formatNum(stats.iops_read, 0)} iops`));
+      });
+
+      it('shows write iops', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.queryByTestId('loading-fs')).not.toBeInTheDocument();
+
+        expect(screen.getByText(`${formatNum(stats.iops_write, 0)} iops`));
+      });
+
+      it('shows read rate', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.queryByTestId('loading-fs')).not.toBeInTheDocument();
+
+        expect(
+          screen.getByText(
+            `${prettyBytes(stats.bps_read, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}/s`,
+          ),
+        );
+      });
+
+      it('shows write rate', async () => {
+        setup();
+
+        await waitForTableRender();
+
+        expect(screen.queryByTestId('loading-fs')).not.toBeInTheDocument();
+
+        expect(
+          screen.getByText(
+            `${prettyBytes(stats.bps_write, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}/s`,
+          ),
+        );
+      });
+    });
+  });
+
+  describe('the "Shards" cell', () => {
+    it('shows the initializing shards', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const initializingShards = shards.filter(
+        s => s.node_id == clusterNode.id && s.routing_state == 'INITIALIZING',
+      ).length;
+
+      expect(screen.getByTestId('initializing-shards')).toHaveTextContent(
+        initializingShards.toString(),
+      );
+    });
+
+    it('shows the started shards', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const startedShards = shards.filter(
+        s => s.node_id == clusterNode.id && s.routing_state == 'STARTED',
+      ).length;
+
+      expect(screen.getByTestId('started-shards')).toHaveTextContent(
+        startedShards.toString(),
+      );
+    });
+
+    it('shows the relocating shards', async () => {
+      setup();
+
+      await waitForTableRender();
+
+      const relocatingShards = shards.filter(
+        s => s.node_id == clusterNode.id && s.routing_state == 'RELOCATING',
+      ).length;
+
+      expect(screen.getByTestId('relocating-shards')).toHaveTextContent(
+        relocatingShards.toString(),
+      );
+    });
+  });
+});

--- a/src/routes/TablePolicies/views/PoliciesLogs.tsx
+++ b/src/routes/TablePolicies/views/PoliciesLogs.tsx
@@ -51,9 +51,7 @@ const getColumnsDefinition = () => {
           <div className="flex flex-col">
             <Link to={`./${encodeURIComponent(log.job_id)}`}>{name}</Link>
             <span className="text-[8px]">
-              {isRunning && (
-                <Chip className="bg-orange-400 text-white">RUNNING</Chip>
-              )}
+              {isRunning && <Chip color={Chip.colors.ORANGE}>RUNNING</Chip>}
             </span>
           </div>
         );

--- a/src/routes/TablePolicies/views/PoliciesTable.tsx
+++ b/src/routes/TablePolicies/views/PoliciesTable.tsx
@@ -85,7 +85,7 @@ const getColumnsDefinition = ({
           <div className="flex flex-col">
             <Text>{name}</Text>
             <span className="text-[8px]">
-              {running && <Chip className="bg-orange-400 text-white">RUNNING</Chip>}
+              {running && <Chip color={Chip.colors.ORANGE}>RUNNING</Chip>}
             </span>
           </div>
         );

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -50,6 +50,15 @@ export type FSInfo = {
   };
 };
 
+export type MemInfo = {
+  free_percent: number;
+  used_percent: number;
+  free: number;
+  used: number;
+};
+
+export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'GOOD';
+
 export type NodeStatusInfo = {
   id: string;
   name: string;
@@ -63,6 +72,7 @@ export type NodeStatusInfo = {
   rest_url: string;
   os_info: OSInfo;
   timestamp: number;
+  mem: MemInfo;
   attributes: { [key: string]: string };
 };
 
@@ -111,7 +121,7 @@ export type ShardInfo = {
   node_id: string;
   state: string;
   routing_state: string;
-  relocating_node: string;
+  relocating_node: string | null;
   number_of_shards: number;
   primary: boolean;
   total_docs: number;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,4 +7,6 @@ export * from './arrays';
 export * from './strings';
 export * from './compare';
 export * from './jobLogs';
+export * from './numbers';
 export * from './sorting';
+export * from './nodes';

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,0 +1,21 @@
+import { NODE_STATUS_THRESHOLD } from 'constants/database';
+import { NodeStatus, NodeStatusInfo } from 'types/cratedb';
+
+export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
+  const fs_used_percent = (node.fs.total.used * 100) / node.fs.total.size;
+  const heap_used_percent = (node.heap.used * 100) / node.heap.max;
+
+  if (fs_used_percent === 0 && heap_used_percent === 0) {
+    return 'UNREACHABLE';
+  } else {
+    const used = Math.max(fs_used_percent, heap_used_percent);
+
+    if (used > NODE_STATUS_THRESHOLD.CRITICAL) {
+      return 'CRITICAL';
+    } else if (used > NODE_STATUS_THRESHOLD.WARNING) {
+      return 'WARNING';
+    } else {
+      return 'GOOD';
+    }
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,10 @@ module.exports = {
         'crate-form-disabled': '#f5f5f5',
         'crate-gray30': '#777',
         transparent: 'transparent',
+
+        // Components
+        // Table
+        'table-row-hover': '#fafafa',
       },
       fontFamily: {
         inter: ['Inter', 'Arial', 'sans-serif'],

--- a/test/__mocks__/nodes.ts
+++ b/test/__mocks__/nodes.ts
@@ -1,0 +1,174 @@
+import { NodeStatusInfo } from 'types/cratedb';
+
+export const clusterNodes: NodeStatusInfo[] = [
+  {
+    id: 'BFHeuv7bRGyPFSYNS2k8eQ',
+    name: 'cratedb',
+    hostname: '9fb7b3dfbded',
+    heap: {
+      used: 889502872,
+      free: 1257980776,
+      max: 2147483648,
+      probe_timestamp: 1713516274938,
+    },
+    fs: {
+      total: {
+        bytes_written: 0,
+        size: 1000240963584,
+        available: 851841318912,
+        reads: 0,
+        bytes_read: 0,
+        used: 148399644672,
+        writes: 0,
+      },
+    },
+    load: {
+      '1': 8,
+      '5': 4,
+      '15': 2,
+      probe_timestamp: 1713516274941,
+    },
+    version: {
+      number: '5.6.4',
+    },
+    crate_cpu_usage: 0,
+    available_processors: 16,
+    rest_url: '172.23.0.2:4200',
+    os_info: {
+      available_processors: 16,
+      name: 'Linux',
+      jvm: {
+        vm_vendor: 'Eclipse Adoptium',
+        vm_version: '21.0.2+13-LTS',
+        version: '21.0.2',
+        vm_name: 'OpenJDK 64-Bit Server VM',
+      },
+      arch: 'amd64',
+      version: '6.5.11-linuxkit',
+    },
+    timestamp: 1713516274933,
+    attributes: {
+      attribute_key: 'attribute_value',
+    },
+    mem: {
+      free_percent: 22,
+      used_percent: 78,
+      used: 6429339648,
+      free: 1800056832,
+    },
+  },
+  {
+    id: 'xXT-4KS1SO20mf7kY6DfWA',
+    name: 'cratedb02',
+    hostname: 'bbf3a78ed507',
+    heap: {
+      used: 1060020480,
+      free: 1087463168,
+      max: 2147483648,
+      probe_timestamp: 1713516274938,
+    },
+    fs: {
+      total: {
+        bytes_written: 0,
+        size: 1000240963584,
+        available: 851841318912,
+        reads: 0,
+        bytes_read: 0,
+        used: 148399644672,
+        writes: 0,
+      },
+    },
+    load: {
+      '1': 0.03,
+      '5': 0.06,
+      '15': 0.02,
+      probe_timestamp: 1713516274939,
+    },
+    version: {
+      number: '5.6.4',
+    },
+    crate_cpu_usage: 0,
+    available_processors: 16,
+    rest_url: '172.23.0.3:4200',
+    os_info: {
+      available_processors: 16,
+      name: 'Linux',
+      jvm: {
+        vm_vendor: 'Eclipse Adoptium',
+        vm_version: '21.0.2+13-LTS',
+        version: '21.0.2',
+        vm_name: 'OpenJDK 64-Bit Server VM',
+      },
+      arch: 'amd64',
+      version: '6.5.11-linuxkit',
+    },
+    timestamp: 1713516274933,
+    attributes: {},
+    mem: {
+      free_percent: 22,
+      used_percent: 78,
+      used: 6429339648,
+      free: 1800056832,
+    },
+  },
+  {
+    id: '5QAukOpWQDCTzn61eI6TfQ',
+    name: 'cratedb03',
+    hostname: 'fd9750a7404c',
+    heap: {
+      used: 99154384,
+      free: 2048329264,
+      max: 2147483648,
+      probe_timestamp: 1713516274938,
+    },
+    fs: {
+      total: {
+        bytes_written: 0,
+        size: 1000240963584,
+        available: 851841318912,
+        reads: 0,
+        bytes_read: 0,
+        used: 148399644672,
+        writes: 0,
+      },
+    },
+    load: {
+      '1': 0.03,
+      '5': 0.06,
+      '15': 0.02,
+      probe_timestamp: 1713516274940,
+    },
+    version: {
+      number: '5.6.4',
+    },
+    crate_cpu_usage: 0,
+    available_processors: 16,
+    rest_url: '172.23.0.4:4200',
+    os_info: {
+      available_processors: 16,
+      name: 'Linux',
+      jvm: {
+        vm_vendor: 'Eclipse Adoptium',
+        vm_version: '21.0.2+13-LTS',
+        version: '21.0.2',
+        vm_name: 'OpenJDK 64-Bit Server VM',
+      },
+      arch: 'amd64',
+      version: '6.5.11-linuxkit',
+    },
+    timestamp: 1713516274933,
+    attributes: {
+      attribute1: 'value1',
+      attribute3: 'value3',
+      attribute2: 'value2',
+    },
+    mem: {
+      free_percent: 22,
+      used_percent: 78,
+      used: 6429339648,
+      free: 1800056832,
+    },
+  },
+];
+
+export const clusterNode: NodeStatusInfo = clusterNodes[0];

--- a/test/__mocks__/query.ts
+++ b/test/__mocks__/query.ts
@@ -1,3 +1,4 @@
+import { NodeStatusInfo, ShardInfo } from 'types/cratedb';
 import { QueryResult } from '../../src/types/query';
 
 export const queryResult: QueryResult = {
@@ -21,4 +22,244 @@ export const schemasQueryResult: QueryResult = {
   rows: [['policy_tests', 'parted_table', 4, '0-1', ['part'], false]],
   rowcount: 1,
   duration: 1.179331,
+};
+
+export const singleNodesQueryResult = (clusterNode: NodeStatusInfo): QueryResult => {
+  return {
+    cols: [
+      'id',
+      'name',
+      'hostname',
+      'heap',
+      'fs',
+      'load',
+      'version',
+      'cpu_usage',
+      'available_processors',
+      'rest_url',
+      'os_info',
+      'now()',
+      'attributes',
+      'mem',
+    ],
+    col_types: [4, 4, 4, 12, 12, 12, 12, 8, 9, 4, 12, 11, 12, 12],
+    rows: [
+      [
+        clusterNode.id,
+        clusterNode.name,
+        clusterNode.hostname,
+        clusterNode.heap,
+        clusterNode.fs,
+        clusterNode.load,
+        clusterNode.version,
+        clusterNode.crate_cpu_usage,
+        clusterNode.available_processors,
+        clusterNode.rest_url,
+        clusterNode.os_info,
+        1713515699109,
+        clusterNode.attributes,
+        clusterNode.mem,
+      ],
+    ],
+    rowcount: 3,
+    duration: 6.938865,
+  };
+};
+
+export const clusterInfoQueryResult: QueryResult = {
+  cols: ['id', 'name', 'master_node', 'settings'],
+  col_types: [4, 4, 4, 12],
+  rows: [
+    [
+      'linWj13gQleu6b7T_lj2DQ',
+      'crate-docker-cluster',
+      'BFHeuv7bRGyPFSYNS2k8eQ',
+      {
+        replication: {
+          logical: {
+            reads_poll_duration: '50ms',
+            ops_batch_size: 50000,
+            recovery: {
+              chunk_size: '1mb',
+              max_concurrent_file_chunks: 2,
+            },
+          },
+        },
+        overload_protection: {
+          dml: {
+            max_concurrency: 2000,
+            queue_size: 200,
+            initial_concurrency: 5,
+            min_concurrency: 1,
+          },
+        },
+        cluster: {
+          routing: {
+            rebalance: {
+              enable: 'all',
+            },
+            allocation: {
+              include: {
+                _id: '',
+                _host: '',
+                _name: '',
+                _ip: '',
+              },
+              disk: {
+                threshold_enabled: true,
+                watermark: {
+                  low: '85%',
+                  flood_stage: '95%',
+                  high: '90%',
+                },
+              },
+              node_initial_primaries_recoveries: 4,
+              balance: {
+                index: 0.55,
+                threshold: 1,
+                shard: 0.45,
+              },
+              total_shards_per_node: -1,
+              enable: 'all',
+              allow_rebalance: 'indices_all_active',
+              cluster_concurrent_rebalance: 2,
+              node_concurrent_recoveries: 2,
+              exclude: {
+                _id: '',
+                _host: '',
+                _name: '',
+                _ip: '',
+              },
+              require: {
+                _id: '',
+                _host: '',
+                _name: '',
+                _ip: '',
+              },
+            },
+          },
+          graceful_stop: {
+            timeout: '7200000ms',
+            min_availability: 'PRIMARIES',
+            force: false,
+          },
+          max_shards_per_node: 1000,
+          info: {
+            update: {
+              interval: '30s',
+            },
+          },
+        },
+        indices: {
+          breaker: {
+            request: {
+              limit: '1.1gb',
+            },
+            total: {
+              limit: '1.8gb',
+            },
+            query: {
+              limit: '1.1gb',
+            },
+          },
+          replication: {
+            retry_timeout: '60s',
+          },
+          recovery: {
+            recovery_activity_timeout: '1800000ms',
+            retry_delay_network: '5s',
+            internal_action_timeout: '15m',
+            retry_delay_state_sync: '500ms',
+            max_bytes_per_sec: '40mb',
+            internal_action_long_timeout: '1800000ms',
+          },
+        },
+        memory: {
+          allocation: {
+            type: 'on-heap',
+          },
+          operation_limit: 0,
+        },
+        stats: {
+          breaker: {
+            log: {
+              jobs: {
+                limit: '102.3mb',
+              },
+              operations: {
+                limit: '102.3mb',
+              },
+            },
+          },
+          service: {
+            max_bytes_per_sec: '40mb',
+            interval: '24h',
+          },
+          jobs_log_expiration: '0s',
+          operations_log_expiration: '0s',
+          jobs_log_size: 10000,
+          jobs_log_persistent_filter: 'false',
+          operations_log_size: 10000,
+          enabled: true,
+          jobs_log_filter: 'true',
+        },
+        udc: {
+          initial_delay: '10m',
+          interval: '24h',
+          enabled: true,
+          url: 'https://udc.crate.io/',
+        },
+        logger: [],
+        statement_timeout: '0ms',
+        bulk: {
+          request_timeout: '1m',
+        },
+        gateway: {
+          expected_nodes: -1,
+          recover_after_data_nodes: 2,
+          expected_data_nodes: 3,
+          recover_after_nodes: -1,
+          recover_after_time: '0ms',
+        },
+      },
+    ],
+  ],
+  rowcount: 1,
+  duration: 2.34879,
+};
+
+export const shardsQueryResult = (shards: ShardInfo[]): QueryResult => {
+  return {
+    cols: [
+      'table_name',
+      'schema_name',
+      'node_id',
+      'state',
+      'routing_state',
+      'relocating_node',
+      'number_of_shards',
+      'primary',
+      'sum(num_docs)',
+      'avg(num_docs)',
+      'sum(size)',
+    ],
+    col_types: [4, 4, 4, 4, 4, 4, 10, 3, 10, 6, 10],
+    rows: shards.map(el => {
+      return [
+        el.table_name,
+        el.schema_name,
+        el.node_id,
+        el.state,
+        el.routing_state,
+        el.relocating_node,
+        el.number_of_shards,
+        el.primary,
+        el.total_docs,
+        el.avg_docs,
+        el.size_bytes,
+      ];
+    }),
+    rowcount: 8,
+    duration: 52.280266,
+  };
 };

--- a/test/__mocks__/shards.ts
+++ b/test/__mocks__/shards.ts
@@ -1,0 +1,43 @@
+import { ShardInfo } from 'types/cratedb';
+
+export const shards: ShardInfo[] = [
+  {
+    table_name: 'scheduled_jobs',
+    schema_name: 'gc',
+    node_id: 'BFHeuv7bRGyPFSYNS2k8eQ',
+    state: 'STARTED',
+    routing_state: 'STARTED',
+    relocating_node: null,
+    number_of_shards: 1,
+    primary: false,
+    total_docs: 0,
+    avg_docs: 0,
+    size_bytes: 208,
+  },
+  {
+    table_name: 'alembic_version',
+    schema_name: 'gc',
+    node_id: 'BFHeuv7bRGyPFSYNS2k8eQ',
+    state: 'STARTED',
+    routing_state: 'RELOCATING',
+    relocating_node: null,
+    number_of_shards: 1,
+    primary: true,
+    total_docs: 1,
+    avg_docs: 1,
+    size_bytes: 20153,
+  },
+  {
+    table_name: 'jwt_refresh_token',
+    schema_name: 'gc',
+    node_id: 'BFHeuv7bRGyPFSYNS2k8eQ',
+    state: 'STARTED',
+    routing_state: 'RELOCATING',
+    relocating_node: null,
+    number_of_shards: 1,
+    primary: true,
+    total_docs: 0,
+    avg_docs: 0,
+    size_bytes: 208,
+  },
+];

--- a/test/msw/handlers/queries.ts
+++ b/test/msw/handlers/queries.ts
@@ -1,7 +1,20 @@
 import { RestHandler, rest } from 'msw';
-import { queryResult, schemasQueryResult } from '../../__mocks__/query';
+import {
+  clusterInfoQueryResult,
+  queryResult,
+  schemasQueryResult,
+  shardsQueryResult,
+  singleNodesQueryResult,
+} from '../../__mocks__/query';
 import handlerFactory from '../handlerFactory';
-import { getPartitionedTablesQuery } from 'constants/queries';
+import {
+  clusterInfoQuery,
+  getPartitionedTablesQuery,
+  nodesQuery,
+  shardsQuery,
+} from 'constants/queries';
+import { clusterNode } from 'test/__mocks__/nodes';
+import { shards } from 'test/__mocks__/shards';
 
 const executeQueryPost: RestHandler = rest.post(
   '/api/_sql',
@@ -11,6 +24,15 @@ const executeQueryPost: RestHandler = rest.post(
     let result: null | object = null;
 
     switch (body.stmt) {
+      case nodesQuery:
+        result = singleNodesQueryResult(clusterNode);
+        break;
+      case clusterInfoQuery:
+        result = clusterInfoQueryResult;
+        break;
+      case shardsQuery:
+        result = shardsQueryResult(shards);
+        break;
       case getPartitionedTablesQuery(false):
         result = schemasQueryResult;
         break;
@@ -25,4 +47,4 @@ const executeQueryPost: RestHandler = rest.post(
 
 export const executeQueryHandlers: RestHandler[] = [executeQueryPost];
 
-export const customExecuteQueryResponse = handlerFactory('/api/_sql');
+export const customExecuteQueryResponse = handlerFactory('/api/_sql', 'POST');


### PR DESCRIPTION
## Summary of changes
This is a bit different from the old `admin-ui` cluster page, with the goal of improving UI/UX. It uses a table, instead of a list, so it does not require to open different tabs to compare nodes stats.

### Old
![image](https://github.com/crate/crate-gc-admin/assets/33689349/556d40dc-c330-4e3a-af35-43138224437d)

### New
![image](https://github.com/crate/crate-gc-admin/assets/33689349/27ccac23-2c88-401d-bbb9-06c05f5b0c05)

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1802
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests. ✅
- [x] Required Grand Central APIs are already merged.
