### PR TITLE
Remove API requests to get the logs of the last job executions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Remove additional API requests to get the logs of the last
+  executions of a scheduled job.
+
 ## 2024-04-30 - 0.7.2
 
 - Improve Nodes page UI/UX.

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -7,11 +7,9 @@ export type Job = {
   enabled: boolean;
   sql: string;
   next_run_time?: string;
-};
-
-export type EnrichedJob = Job & {
-  last_execution?: JobLog;
   running: boolean;
+  last_job_logs: JobLog[] | null;
+  last_execution: JobLog | null;
 };
 
 export type TJobLogStatementError = {

--- a/test/__mocks__/scheduledJob.ts
+++ b/test/__mocks__/scheduledJob.ts
@@ -7,6 +7,9 @@ const scheduledJob: Job = {
   name: 'JobName',
   next_run_time: '2024-01-18T14:38:00+00:00',
   sql: 'SELECT 1;',
+  running: false,
+  last_job_logs: null,
+  last_execution: null,
 };
 
 export default scheduledJob;

--- a/test/__mocks__/scheduledJobs.ts
+++ b/test/__mocks__/scheduledJobs.ts
@@ -8,6 +8,9 @@ const scheduledJobs: Job[] = [
     name: 'Test',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'SELECT 1;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -16,6 +19,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 6',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'SELECT 6;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -24,6 +30,9 @@ const scheduledJobs: Job[] = [
     name: 'Test 3',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'SELECT 3;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -32,6 +41,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 2',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'SELECT 1;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -40,6 +52,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 5',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'SELECT 5;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -48,6 +63,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 41',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -56,6 +74,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 42',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -64,6 +85,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 7',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -72,6 +96,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 48',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -80,6 +107,9 @@ const scheduledJobs: Job[] = [
     name: 'Job 009',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
   {
     cron: '* * * * *',
@@ -88,6 +118,9 @@ const scheduledJobs: Job[] = [
     name: 'New Job 009',
     next_run_time: '2024-01-19T10:25:00+00:00',
     sql: 'select 4;',
+    running: false,
+    last_job_logs: null,
+    last_execution: null,
   },
 ].sort((a: Job, b: Job) => {
   if (a.name < b.name) {


### PR DESCRIPTION
## Summary of changes
This removes the additional API call to retrieve the latest 2 job logs for each job. They are returned by the API now in the output of the scheduled-jobs list endpoint.

! This requires API changes to be released first https://github.com/crate/grand-central/pull/95 !
## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1648
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
