### PR TITLE
Renew JWT only on 401 and 403 HTTP error codes from GC APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-07-15 - 0.9.1
+
+- Renew JWT only on 401 and 403 HTTP error codes from GC.
+
 ## 2024-07-15 - 0.9.0
 
 - Split and execute queries sequentially using cratedb-sqlparse.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/hooks/useGcApi.ts
+++ b/src/hooks/useGcApi.ts
@@ -1,6 +1,11 @@
-import axios from 'axios';
+import axios, { HttpStatusCode } from 'axios';
 import Cookies from 'js-cookie';
 import { useGCContext } from 'contexts';
+
+const RENEW_JWT_CODES: HttpStatusCode[] = [
+  HttpStatusCode.Unauthorized, // 401
+  HttpStatusCode.Forbidden, // 403
+];
 
 export default function useGcApi() {
   const { gcUrl, onGcApiJwtExpire, sessionCookieName } = useGCContext();
@@ -27,7 +32,7 @@ export default function useGcApi() {
         if (err.response) {
           // Check if Access Token was expired
           if (
-            err.response.status >= 401 &&
+            RENEW_JWT_CODES.includes(err.response.status) &&
             !originalConfig._retry &&
             onGcApiJwtExpire
           ) {


### PR DESCRIPTION
## Summary of changes
Found out that the SQL proxy (on GC) is returning 404 when a query like `SELECT abc` fails, causing JWT renew. The change is to make the JWT renew only for 401 and 403 error codes. This PR also increase the package version to 0.9.1.

![image](https://github.com/user-attachments/assets/59f2bbbc-4c26-408b-badc-f131f6a8f641)

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1888
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
