### PR TITLE
Per-cluster SQL console history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-07-31 - 0.9.2
+
+- Add clusterID to context, filter SQL console history by cluster.
+
 ## 2024-07-15 - 0.9.1
 
 - Renew JWT only on 401 and 403 HTTP error codes from GC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/SQLEditor/SQLEditor.test.tsx
+++ b/src/components/SQLEditor/SQLEditor.test.tsx
@@ -324,8 +324,8 @@ describe('The SQLEditor component', () => {
   });
 
   describe('when localStorageKey is set', () => {
-    const LOCAL_STORAGE_VALUE_KEY = 'crate.gc.admin.test';
-    const LOCAL_STORAGE_HISTORY_KEY = 'crate.gc.admin.test-history';
+    const LOCAL_STORAGE_VALUE_KEY = 'crate.gc.admin.test.';
+    const LOCAL_STORAGE_HISTORY_KEY = 'crate.gc.admin.test-history.';
 
     const initializeLocalStorage = (value: string, history: string) => {
       localStorage.setItem(LOCAL_STORAGE_VALUE_KEY, value);

--- a/src/components/SQLEditor/SQLEditor.tsx
+++ b/src/components/SQLEditor/SQLEditor.tsx
@@ -16,6 +16,7 @@ import { SchemaTableColumn } from 'types/cratedb';
 import { useGetTableColumnsQuery } from 'hooks/queryHooks';
 import { Loader, Text, Button, CopyToClipboard } from 'components';
 import { SYSTEM_SCHEMAS } from 'constants/database';
+import { useGCContext } from 'contexts';
 
 export type SQLEditorProps = {
   value?: string | undefined | null;
@@ -61,12 +62,16 @@ function SQLEditor({
   onViewHistory,
   title,
 }: SQLEditorProps) {
+  const { clusterId } = useGCContext();
+
   const SQL_EDITOR_CONTENT_KEY =
-    localStorageKey && `crate.gc.admin.${localStorageKey}`;
+    localStorageKey && `crate.gc.admin.${localStorageKey}.${clusterId || ''}`;
   const SQL_HISTORY_CONTENT_KEY =
-    localStorageKey && `crate.gc.admin.${localStorageKey}-history`;
+    localStorageKey &&
+    `crate.gc.admin.${localStorageKey}-history.${clusterId || ''}`;
   const SQL_HISTORY_TEMP_CONTENT_KEY =
-    localStorageKey && `crate.gc.admin.${localStorageKey}-history-temp`;
+    localStorageKey &&
+    `crate.gc.admin.${localStorageKey}-history-temp.${clusterId || ''}`;
 
   const getTableColumns = useGetTableColumnsQuery();
   const dataFromLocalStorage = SQL_EDITOR_CONTENT_KEY

--- a/src/contexts/GrandCentral.tsx
+++ b/src/contexts/GrandCentral.tsx
@@ -8,6 +8,7 @@ type GCContextType = {
   sessionCookieName: string;
   headings?: boolean;
   onGcApiJwtExpire?: () => Promise<void>;
+  clusterId?: string;
 };
 
 export enum ConnectionStatus {
@@ -24,6 +25,7 @@ const defaultProps: GCContextType = {
   sessionCookieName: GRAND_CENTRAL_TOKEN_COOKIE,
   crateUrl: undefined,
   headings: true,
+  clusterId: undefined,
 };
 
 const GCContext = React.createContext<GCContextType>(defaultProps);

--- a/src/routes/SQLConsole/SQLConsole.tsx
+++ b/src/routes/SQLConsole/SQLConsole.tsx
@@ -2,8 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { NoDataView, SQLEditor, SQLHistory, SQLResults } from 'components';
 import useExecuteMultiSql from 'hooks/useExecuteMultiSql';
+import { useGCContext } from 'contexts';
 
-type SQLConsoleProps = { onQuery?: () => void; onViewHistory?: () => void };
+type SQLConsoleProps = {
+  onQuery?: () => void;
+  onViewHistory?: () => void;
+};
 
 function SQLConsole({ onQuery, onViewHistory }: SQLConsoleProps) {
   const { executeSqlWithStatus, queryResults, resetResults } = useExecuteMultiSql();
@@ -13,6 +17,7 @@ function SQLConsole({ onQuery, onViewHistory }: SQLConsoleProps) {
   const [rerender, setRerender] = useState(false);
   const outerHeight = useRef(null);
   const innerHeight = useRef(null);
+  const { clusterId } = useGCContext();
 
   // if a query is specified in the URL, place it in the editor
   useEffect(() => {
@@ -30,7 +35,7 @@ function SQLConsole({ onQuery, onViewHistory }: SQLConsoleProps) {
   };
 
   const LOCAL_STORAGE_KEY = 'sql-editor';
-  const SQL_HISTORY_CONTENT_KEY = `crate.gc.admin.${LOCAL_STORAGE_KEY}-history`;
+  const SQL_HISTORY_CONTENT_KEY = `crate.gc.admin.${LOCAL_STORAGE_KEY}-history.${clusterId || ''}`;
   const history = JSON.parse(localStorage.getItem(SQL_HISTORY_CONTENT_KEY) || '[]');
 
   const clearHistory = () => {


### PR DESCRIPTION
## Summary of changes
Include the cluster ID (an empty string outside of the cloud console) when managing the SQL console history, enabling per-cluster history. 

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1983
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
