### PR TITLE
Per-cluster SQL console history version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Check if version has been updated
         id: check
         uses: EndBug/version-check@v2
+        with:
+          diff-search: true
 
       - name: Install dependencies
         if: steps.check.outputs.changed == 'true'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 2024-08-02 - 0.9.3
+## 2024-08-02 - 0.9.4
 
 - Add clusterID to context, filter SQL console history by cluster.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "crate.io",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary of changes
Attempt to remedy GitHub npm publish action not picking up version number change. 

## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
