### PR TITLE
Display RAW boolean SQL results correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-08-06 - 0.9.6
+
+- Fix bug in SQL results to show booleans in RAW output correctly.
+
 ## 2024-08-06 - 0.9.5
 
 - Mark VIEWs and FOREIGN TABLEs as such in the Console Table tree.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/SQLResults/SQLResultsTable.tsx
+++ b/src/components/SQLResults/SQLResultsTable.tsx
@@ -88,6 +88,9 @@ function SQLResultsTable({ result }: Params) {
         />
       );
     }
+    if (tableResultsFormat == 'raw' && typeof value == 'boolean') {
+      return value.toString();
+    }
     if (typeof value == 'object') {
       return JSON.stringify(value);
     }


### PR DESCRIPTION
## Summary of changes
Tiny fix to show raw SQL values correctly in the SQL results output when in RAW mode.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1861
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
