### PR TITLE
Handle sqlparse errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-08-12 - 0.10.3
+
+- Handle sqlparse errors.
+
 ## 2024-08-08 - 0.10.2
 
 - Change operation labels in policy form.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/hooks/useExecuteMultiSql.ts
+++ b/src/hooks/useExecuteMultiSql.ts
@@ -1,4 +1,5 @@
 import { sqlparse } from '@cratedb/cratedb-sqlparse';
+import { Statement } from 'node_modules/@cratedb/cratedb-sqlparse/dist/parser';
 import { QueryResult, QueryStatus, QueryStatusType } from 'types/query';
 import useExecuteSql from './useExecuteSql';
 import { HttpStatusCode } from 'axios';
@@ -49,9 +50,18 @@ export default function useExecuteMultiSql() {
     executionId.current = executionId.current + 1;
 
     // Parse queries
-    const parsedQueries = parseQueries(multipleQueries);
-
-    const errorStatement = parsedQueries.find(stmt => stmt.exception);
+    let parsedQueries: Statement[];
+    let errorStatement;
+    // let errorStatement = null;
+    try {
+      parsedQueries = parseQueries(multipleQueries);
+      errorStatement = parsedQueries.find(stmt => stmt.exception);
+    } catch (e) {
+      parsedQueries = [];
+      errorStatement = {
+        exception: { line: 1, message: 'Unable to parse queries' },
+      };
+    }
 
     if (errorStatement) {
       // set error


### PR DESCRIPTION
## Summary of changes
Not sure what is the best way of defining the type of `parsedQueries` on line #52. Would it be to update the `@cratedb/cratedb-sqlparse` library to export the `Statement` class from `parser.d.ts`?

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2032
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
