### PR TITLE
Tab change content jump fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-09-23 - 0.13.4
+
+- Fix minor issue with content jumping when navigating between tabs.
+
 ## 2024-09-20 - 0.13.3
 
 - Fix edge-case bug where tabs don't always display when hideWhenSingleTab is set.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/CrateTabsShad/CrateTabsShad.tsx
+++ b/src/components/CrateTabsShad/CrateTabsShad.tsx
@@ -49,7 +49,7 @@ function CrateTabsShad({
       onValueChange={onTabChange}
     >
       <TabsList
-        className={hideWhenSingleTab && items.length === 1 ? 'hidden' : 'border-b'}
+        className={`min-h-10 ${hideWhenSingleTab && items.length === 1 ? 'hidden' : 'border-b'}`}
       >
         {items.map(item => (
           <TabsTrigger key={item.key} value={item.key}>
@@ -61,7 +61,7 @@ function CrateTabsShad({
         <TabsContent
           key={item.key}
           value={item.key}
-          className={stickyTabBar ? 'h-full w-full overflow-hidden' : ''}
+          className={stickyTabBar ? 'w-full grow overflow-hidden' : ''}
         >
           {item.content}
         </TabsContent>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -154,7 +154,7 @@ export function DataTable<TData, TValue>({
 
     return (
       <div
-        className={`flex h-10 items-center justify-between px-2 py-1 ${paginationAtTop ? 'border-b' : 'border-t'}`}
+        className={`flex min-h-10 items-center justify-between px-2 py-1 ${paginationAtTop ? 'border-b' : 'border-t'}`}
       >
         {paginationContent ? paginationContent : <div />}
         {!(pageCount === 1 && hidePaginationWhenSinglePage) && (

--- a/src/components/SQLResults/SQLResultsTable.tsx
+++ b/src/components/SQLResults/SQLResultsTable.tsx
@@ -312,7 +312,7 @@ function SQLResultsTable({ result }: Params) {
         elementsPerPage={100}
         hidePaginationPageSize
         stickyHeader
-        className="h-full w-full overflow-auto"
+        className="w-full overflow-auto"
         paginationAtTop
         paginationContent={
           <div className="flex w-full items-center gap-4">

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cn } from 'utils';
 
 const Table = ({ className, ...props }: React.ComponentProps<'table'>) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full grow overflow-auto">
     <table
       className={cn('w-full caption-bottom text-[14px]', className)}
       {...props}


### PR DESCRIPTION
## Summary of changes
Tiny CSS fix to prevent the contents of the tabs "jumping" when navigating between them. Happens when one tab has scrollbars (i.e. content bigger than the container) and one doesn't. 

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2006
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
