### PR TITLE
Prevent SQL editor re-renders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-10-01 - 0.14.2
+
+- Fix bug where the SQL editor was re-rendering too frequently.
+
 ## 2024-09-27 - 0.14.1
 
 - Fix bug where JWT calls to the database were still being sent to Grand Central.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "crate.io",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary of changes
The SQL editor component was re-rendering on every keystroke as it was storing the ace editor value in state. As this value is easily pulled from the editor without state being required, I refactored the component to do that.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2131
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
