### PR TITLE
Store cluster schema data in a context provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-10-02 - 0.15.0
+
+- Refactor schema fetching to store values in a context provider for re-use elsewhere.
+
 ## 2024-10-01 - 0.14.2
 
 - Fix bug where the SQL editor was re-rendering too frequently.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,11 @@ import { Link, Route, Routes } from 'react-router-dom';
 import { bottomNavigation, topNavigation } from 'constants/navigation';
 import routes from 'constants/routes';
 import { useMemo, useState } from 'react';
-import { ConnectionStatus, GCContextProvider } from 'contexts';
+import {
+  ConnectionStatus,
+  GCContextProvider,
+  SchemaTreeContextProvider,
+} from 'contexts';
 import { Layout, StatusBar, StatsUpdater } from 'components';
 import logo from './assets/logo.svg';
 import useGcApi from 'hooks/useGcApi';
@@ -41,24 +45,26 @@ function App() {
       crateUrl={crateUrl}
       sessionTokenKey={GRAND_CENTRAL_SESSION_TOKEN_KEY}
     >
-      <StatsUpdater />
-      <Layout
-        topbarLogo={
-          <Link to={root.build()}>
-            <img alt="CrateDB logo" src={logo} />
-          </Link>
-        }
-        topbarContent={<StatusBar />}
-        bottomNavigation={bottomNavigation}
-        topNavigation={topNavigation}
-      >
-        <Routes>
-          {routes.map(route => (
-            <Route key={route.path} path={route.path} element={route.element} />
-          ))}
-        </Routes>
-      </Layout>
-      <NotificationHandler />
+      <SchemaTreeContextProvider>
+        <StatsUpdater />
+        <Layout
+          topbarLogo={
+            <Link to={root.build()}>
+              <img alt="CrateDB logo" src={logo} />
+            </Link>
+          }
+          topbarContent={<StatusBar />}
+          bottomNavigation={bottomNavigation}
+          topNavigation={topNavigation}
+        >
+          <Routes>
+            {routes.map(route => (
+              <Route key={route.path} path={route.path} element={route.element} />
+            ))}
+          </Routes>
+        </Layout>
+        <NotificationHandler />
+      </SchemaTreeContextProvider>
     </GCContextProvider>
   );
 }

--- a/src/components/SQLEditor/SQLEditor.test.tsx
+++ b/src/components/SQLEditor/SQLEditor.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from 'test/testUtils';
 import SQLEditor, { SQLEditorProps } from './SQLEditor';
 import { SYSTEM_SCHEMAS } from 'constants/database';
 import {
-  schameTablesNonSystemMock,
+  schemaTablesNonSystemMock,
   schemaTableColumnMock,
 } from 'test/__mocks__/schemaTableColumn';
 import _ from 'lodash';
@@ -58,7 +58,6 @@ const triggerTreeItem = async (
     ?.getElementsByClassName('ant-tree-switcher')[0];
 
   await user.click(triggerIcon!);
-
   if (textToWait) {
     // wait for first element
     await waitFor(() => {
@@ -115,7 +114,7 @@ describe('The SQLEditor component', () => {
         await setup();
 
         // NON SYSTEM schemas should NOT have system text
-        schameTablesNonSystemMock.forEach(schema => {
+        schemaTablesNonSystemMock.forEach(schema => {
           expect(screen.getByTestId(`schema-${schema}`)).toBeInTheDocument();
           expect(
             within(screen.getByTestId(`schema-${schema}`)).queryByText('system'),

--- a/src/contexts/SchemaTree.tsx
+++ b/src/contexts/SchemaTree.tsx
@@ -1,0 +1,169 @@
+import React, { PropsWithChildren, useContext, useEffect, useState } from 'react';
+import useExecuteSql from 'hooks/useExecuteSql';
+import { SYSTEM_SCHEMAS } from 'constants/database';
+import { getTablesColumnsQuery } from 'constants/queries';
+
+const REFRESH_INTERVAL_SECONDS = 60;
+
+// a schema description row, as returned direct from the DB
+type SchemaDescription = {
+  table_schema: string;
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  table_type: string;
+};
+
+export type SchemaTableColumn = {
+  column_name: string;
+  data_type: string;
+  path: string;
+};
+
+type SchemaTableType = 'BASE TABLE' | 'VIEW' | 'FOREIGN';
+
+export type SchemaTable = {
+  table_name: string;
+  table_type: SchemaTableType;
+  path: string;
+  columns: SchemaTableColumn[];
+  is_system_table: boolean;
+};
+
+export type Schema = {
+  schema_name: string;
+  path: string;
+  tables: SchemaTable[];
+};
+
+type SchemaTreeContextType = {
+  schemaTree: Schema[];
+  refreshSchemaTree: () => void;
+};
+
+const defaultProps: SchemaTreeContextType = {
+  schemaTree: [],
+  refreshSchemaTree: () => {},
+};
+
+const SchemaTreeContext = React.createContext(defaultProps);
+
+export const SchemaTreeContextProvider = ({ children }: PropsWithChildren) => {
+  const executeSql = useExecuteSql();
+  const [lastSync, setLastSync] = useState<number>(0);
+  const [schemaTree, setSchemaTree] = useState<Schema[]>([]);
+
+  const constructSchemaTreeFromFlatList = (input: SchemaDescription[]) => {
+    const constructTables = (input: SchemaDescription[]): SchemaTable[] => {
+      const tree: SchemaTable[] = [];
+
+      // for convenience, create a lookup dict of the tables/columns in this schema
+      const tableLookup: {
+        [key: string]: {
+          name: string;
+          type: string;
+          path: string;
+          is_system_table: boolean;
+        };
+      } = input.reduce((prev, next) => {
+        return {
+          ...prev,
+          [next.table_name]: {
+            name: next.table_name as string,
+            type: next.table_type,
+            path: `${next.table_schema}.${next.table_name}`,
+            schema: next.table_schema,
+            is_system_table: SYSTEM_SCHEMAS.includes(next.table_schema),
+          },
+        };
+      }, {});
+
+      // loop through array of tables
+      const tableNames = [...new Set(input.map(i => i.table_name))];
+      tableNames.forEach(tableName => {
+        tree.push({
+          table_name: tableLookup[tableName].name,
+          table_type: tableLookup[tableName].type as SchemaTableType,
+          path: tableLookup[tableName].path,
+          is_system_table: tableLookup[tableName].is_system_table,
+          columns: input
+            .filter(i => i.table_name === tableName)
+            .map(column => ({
+              column_name: column.column_name,
+              data_type: column.data_type,
+              path: `${tableLookup[tableName].path}.${column.column_name}`,
+            })),
+        });
+      });
+
+      return tree;
+    };
+
+    const constructSchemas = (input: SchemaDescription[]): Schema[] => {
+      const tree: Schema[] = [];
+
+      // loop through array of unique schema names
+      const schemaNames = [...new Set(input.map(i => i.table_schema))];
+      schemaNames.forEach(schemaName => {
+        tree.push({
+          schema_name: schemaName,
+          path: schemaName,
+          tables: constructTables(input.filter(i => i.table_schema === schemaName)),
+        });
+      });
+
+      return tree;
+    };
+
+    return constructSchemas(input);
+  };
+
+  const retrieveSchemaFromCluster = async () => {
+    let cols: SchemaDescription[] = [];
+
+    setLastSync(new Date().valueOf());
+    const res = await executeSql(getTablesColumnsQuery);
+    if (res.data && !('error' in res.data) && !Array.isArray(res.data)) {
+      cols = res.data.rows.map(r => ({
+        table_schema: r[0],
+        table_name: r[1],
+        column_name: r[2],
+        data_type: r[3],
+        table_type: r[4],
+      }));
+    }
+
+    setSchemaTree(constructSchemaTreeFromFlatList(cols));
+  };
+
+  const refreshSchemaTree = () => {
+    retrieveSchemaFromCluster();
+  };
+
+  // populate the tree on mount
+  useEffect(() => {
+    retrieveSchemaFromCluster();
+  }, []);
+
+  // manage the interval timer
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const secondsSinceLastSync = (new Date().valueOf() - lastSync) / 1000;
+      if (secondsSinceLastSync > REFRESH_INTERVAL_SECONDS) {
+        retrieveSchemaFromCluster();
+      }
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [lastSync]);
+
+  return (
+    <SchemaTreeContext.Provider value={{ schemaTree, refreshSchemaTree }}>
+      {children}
+    </SchemaTreeContext.Provider>
+  );
+};
+
+export const useSchemaTreeContext = () => {
+  return useContext(SchemaTreeContext);
+};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './GrandCentral';
+export * from './SchemaTree';

--- a/src/hooks/__test__/useExecuteMultiSql.test.tsx
+++ b/src/hooks/__test__/useExecuteMultiSql.test.tsx
@@ -63,7 +63,8 @@ describe('The useExecuteSql hook', () => {
 
       expect(screen.getByTestId('number-of-queries')).toHaveTextContent('2');
 
-      expect(executeQuerySpy).toHaveBeenCalledTimes(2);
+      // note: the SchemaTreeContextProvider also makes a request, so we expect 3
+      expect(executeQuerySpy).toHaveBeenCalledTimes(3);
     });
 
     it('gets all the statuses', async () => {

--- a/src/hooks/queryHooks.ts
+++ b/src/hooks/queryHooks.ts
@@ -4,7 +4,6 @@ import {
   ClusterInfo,
   NodeStatusInfo,
   QueryStats,
-  SchemaTableColumn,
   ShardInfo,
   TableInfo,
   TableListEntry,
@@ -14,7 +13,6 @@ import useExecuteSql from 'hooks/useExecuteSql';
 import {
   clusterInfoQuery,
   getPartitionedTablesQuery,
-  getTablesColumnsQuery,
   nodesQuery,
   shardsQuery,
 } from 'constants/queries';
@@ -183,28 +181,6 @@ export const useGetTablesQuery = (includeSystemTables: boolean = true) => {
   };
 
   return getTables;
-};
-
-export const useGetTableColumnsQuery = () => {
-  const executeSql = useExecuteSql();
-
-  const getTableColumns = async (): Promise<SchemaTableColumn[]> => {
-    const res = await executeSql(getTablesColumnsQuery);
-
-    if (!res.data || 'error' in res.data || Array.isArray(res.data)) {
-      return [];
-    }
-
-    return res.data.rows.map(r => ({
-      table_schema: r[0],
-      table_name: r[1],
-      column_name: r[2],
-      data_type: r[3],
-      table_type: r[4],
-    }));
-  };
-
-  return getTableColumns;
 };
 
 export const useGetNodesQuery = () => {

--- a/src/routes/Automation/views/JobForm.tsx
+++ b/src/routes/Automation/views/JobForm.tsx
@@ -301,13 +301,7 @@ export default function JobForm(props: JobFormProps) {
                   <Form.Control>
                     <div className="h-72 rounded border-2">
                       <SQLEditor
-                        results={
-                          queryResults
-                            ? queryResults
-                                .filter(el => el.result && 'error' in el.result)
-                                .map(el => el.result!)
-                            : undefined
-                        }
+                        results={queryResults ? queryResults : undefined}
                         localStorageKey="sql-job-editor"
                         value={field.value}
                         onChange={query => {

--- a/src/routes/SQLConsole/SQLConsole.tsx
+++ b/src/routes/SQLConsole/SQLConsole.tsx
@@ -63,13 +63,7 @@ function SQLConsole({ onQuery, onViewHistory }: SQLConsoleProps) {
             <SQLEditor
               onExecute={execute}
               localStorageKey={LOCAL_STORAGE_KEY}
-              results={
-                queryResults
-                  ? queryResults
-                      .filter(el => el.result && 'error' in el.result)
-                      .map(el => el.result!)
-                  : undefined
-              }
+              results={queryResults ? queryResults : undefined}
               setShowHistory={setShowHistory}
               onViewHistory={onViewHistory}
               value={currentQuery}

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -108,14 +108,6 @@ export type TableInfo = {
   constraint_type: string | null;
 };
 
-export type SchemaTableColumn = {
-  table_schema: string;
-  table_name: string;
-  column_name: string;
-  data_type: string;
-  table_type: string;
-};
-
 export type ShardInfo = {
   table_name: string;
   schema_name: string;

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -49,7 +49,7 @@ export type QueryResultSuccess = object & {
   rows: any[][];
   rowcount: number;
   duration: number;
-  original_query?: string;
+  original_query?: Statement;
 };
 
 export type QueryResult = QueryResultSuccess | QueryResultError;

--- a/test/__mocks__/schemaTableColumn.ts
+++ b/test/__mocks__/schemaTableColumn.ts
@@ -1,4 +1,4 @@
-export const schameTablesNonSystemMock = ['new_schema'];
+export const schemaTablesNonSystemMock = ['new_schema'];
 
 export const schemaTableColumnMock = {
   cols: ['table_schema', 'table_name', 'column_name', 'data_type'],

--- a/test/testUtils/renderWithTestWrapper.tsx
+++ b/test/testUtils/renderWithTestWrapper.tsx
@@ -1,7 +1,11 @@
 import React, { PropsWithChildren } from 'react';
 import { render as rtlRender, screen as rtlScreen } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import { ConnectionStatus, GCContextProvider } from 'contexts';
+import {
+  ConnectionStatus,
+  GCContextProvider,
+  SchemaTreeContextProvider,
+} from 'contexts';
 import { SWRConfig } from 'swr';
 import { GRAND_CENTRAL_SESSION_TOKEN_KEY } from 'constants/session';
 
@@ -33,7 +37,7 @@ const render = (ui: React.ReactElement, { ...options } = {}): RenderType => {
             headings
             sessionTokenKey={GRAND_CENTRAL_SESSION_TOKEN_KEY}
           >
-            {children}
+            <SchemaTreeContextProvider>{children}</SchemaTreeContextProvider>
           </GCContextProvider>
         </SWRConfig>
       </main>


### PR DESCRIPTION
## Summary of changes
Initially I tried to build this using a `zustand` store. Unfortunately the SQL calls to either GC, or direct to the cluster using JWT, need parameters held in the `GCContextProvider`. As the zustand store would have been outside the provider's scope, this would mean passing multiple variables around which would have been ugly.

Therefore, I opted to build a new provider to sit as a child of `GCContextProvider` which will store all the schema tree information for the given cluster.

Some features:
- the repeated refresh problem is no longer an issue, instead, it refreshes the schema only when a DDL query (one that changes the schema) has taken place. Note: this removed the need for debounce which has not been implemented.
- the provider refreshes the schema every 2 minutes to incorporate changes that happen outside of the console
- overall, more efficient code and nicer performance 
- we can now use this data in other components, e.g. CloudUI export data

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2126
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
