### PR TITLE
Disable pagination and provide custom header for datatable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-10-17 - 0.15.2
+
+- Add ability to disable pagination and provide a custom header for DataTable.
+
 ## 2024-10-15 - 0.15.1
 
 - Display grouped table columns correctly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -300,4 +300,31 @@ describe('The DataTable component', () => {
       });
     });
   });
+
+  describe('when the pagination is disabled', () => {
+    it('does not display the pagination', () => {
+      setup({ disablePagination: true });
+
+      expect(screen.queryByTestId('datatable-pagination')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when passing in a custom table header', () => {
+    it('renders the custom header, not the standard one', () => {
+      setup({
+        customTableHeader: (
+          <thead data-testId="custom-table-header">
+            <tr>
+              <th></th>
+              <th></th>
+              <th></th>
+            </tr>
+          </thead>
+        ),
+      });
+
+      expect(screen.getByTestId('custom-table-header')).toBeInTheDocument();
+      expect(screen.getAllByRole('columnheader').length).toBe(3);
+    });
+  });
 });

--- a/src/routes/Nodes/Nodes.tsx
+++ b/src/routes/Nodes/Nodes.tsx
@@ -327,7 +327,7 @@ function Nodes() {
             Nodes
           </Heading>
         )}
-        <DataTable columns={columns} data={nodes!} />
+        <DataTable columns={columns} data={nodes!} disablePagination />
       </div>
     </GCSpin>
   );


### PR DESCRIPTION
## Summary of changes
This PR introduces two changes to `DataTable`:
- Be able to disable pagination entirely via a `hidePagination`
- Be able to provide a custom header. 

Why provide a custom header? I'll try and keep this brief:
- my requirement was to add filtering within the column header of the table, very much like how Grafana does it (see image below)
- Ant Design has this kind-of built in to its `Table` but the UI is ugly, has unfriendly UX, cannot be changed.
- React-Table does allow for custom code in the header when defining a column, e.g . `{ header: () => {...} }`, but...
- ...it re-renders the entire table on any change. I tried everything to get around this and couldn't. For this use-case, the UX was awful, with the filter `Popover` animating in and out of view after every click.
- The only way I found (and I tried lots of options ;) ) was to pass in my own `<Table.Header>` which was rendered outside the loops that draw a react-table.
- It would have been ideal NOT to have to do this, but it does give us a lot of flexibility here (including more complex header designs, filtering, searching etc.) which would still be performant on massive amounts of data.

Grafana example:
![image](https://github.com/user-attachments/assets/06cf2d1f-1b4c-40ef-86b0-493103713bbf)

My custom header (in a separate PR, but made possible by this one) with the fancy filtering:
![image](https://github.com/user-attachments/assets/10769598-4f9f-4f8e-9074-efdb9c41f810)

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2140
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
