### PR TITLE
Make location.search optional in DataTable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-10-22 - 0.15.3
+
+- Make location.search optional in DataTable to prevent issues with tests.
+
 ## 2024-10-17 - 0.15.2
 
 - Add ability to disable pagination and provide a custom header for DataTable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/CrateTabs/CrateTabs.tsx
+++ b/src/components/CrateTabs/CrateTabs.tsx
@@ -24,7 +24,7 @@ function CrateTabs({
   // preselected tabs set via URL search params will override
   // the default active key
   const searchParamValue = queryParamKeyActiveTab
-    ? new URLSearchParams(location.search).get(queryParamKeyActiveTab)
+    ? new URLSearchParams(location?.search).get(queryParamKeyActiveTab)
     : null;
   const childKeysIncludesSearchParam = searchParamValue
     ? items
@@ -54,7 +54,7 @@ function CrateTabs({
   // means the browser back button can be used.
   const handleTabClick = (key: string) => {
     if (queryParamKeyActiveTab) {
-      const searchParams = new URLSearchParams(location.search);
+      const searchParams = new URLSearchParams(location?.search);
       searchParams.set(queryParamKeyActiveTab, key);
       navigate(`?${searchParams.toString()}`);
     }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -96,7 +96,7 @@ export function DataTable<TData, TValue>({
   const [sorting, setSorting] = useState<SortingState>(defaultSorting || []);
   const [searchTerm, setSearchTerm] = useState('');
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
-    getFiltersFromQuery(location.search, columns),
+    getFiltersFromQuery(location?.search, columns),
   );
 
   const getReactTableOptions = (): TableOptions<TData> => {
@@ -196,7 +196,7 @@ export function DataTable<TData, TValue>({
 
   // Sync col filters with query param!
   useEffect(() => {
-    const urlSearch = new URLSearchParams(location.search);
+    const urlSearch = new URLSearchParams(location?.search);
 
     // Clean all filter key from urlSearch
     const enableFilterKeys = columns


### PR DESCRIPTION
## Summary of changes
Tiny change to `DataTable` to make the `location.search` optional, otherwise tests that rely on this component are forced to set a location.search value.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2140
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
