### PR TITLE
Hide non top-level columns in DQL statement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-10-29 - 0.16.1
+
+- Hide non top-level columns in DQL statement.
+
 ## 2024-10-29 - 0.16.0
 
 - Add option to generate DQL and DDL statements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/components/SQLEditor/SQLEditorSchemaTree.test.tsx
+++ b/src/components/SQLEditor/SQLEditorSchemaTree.test.tsx
@@ -12,23 +12,29 @@ import {
   getTablesDDLQueryResult,
   getViewsDDLQueryResult,
 } from 'test/__mocks__/query';
+import { SchemaDescription } from 'contexts';
 
 const getSchemaTableColumns = () => {
-  const schemaTableColumnsParsed = schemaTableColumnMock.rows.map(r => ({
-    table_schema: r[0],
-    table_name: r[1],
-    column_name: r[2],
-    quoted_table_schema: r[3],
-    quoted_table_name: r[4],
-    quoted_column_name: r[5],
-    data_type: r[6],
-  }));
+  const schemaTableColumnsParsed = schemaTableColumnMock.rows.map(
+    r =>
+      ({
+        table_schema: r[0] as string,
+        table_name: r[1] as string,
+        column_name: r[2] as string,
+        quoted_table_schema: r[3] as string,
+        quoted_table_name: r[4] as string,
+        quoted_column_name: r[5] as string,
+        data_type: r[6] as string,
+        table_type: r[7] as string,
+        path_array: r[8] as string[],
+      }) satisfies SchemaDescription,
+  );
 
   const groupedBySchema = _.groupBy(schemaTableColumnsParsed, 'table_schema');
 
   return Object.keys(groupedBySchema).map(schema => {
     const schemaTables = groupedBySchema[schema];
-    const tables = [...new Set(schemaTables.map(i => i.table_name))];
+    const tables = [...new Set(schemaTables.map(i => i.table_name as string))];
 
     return {
       schemaName: schema,

--- a/src/components/SQLEditor/SQLEditorSchemaTree.tsx
+++ b/src/components/SQLEditor/SQLEditorSchemaTree.tsx
@@ -209,7 +209,10 @@ function SQLEditorSchemaTree() {
 
       const copySelectStatement = () => {
         // generate DQL
-        const dqlStatement = `SELECT ${table.columns.map(el => el.quoted_column_name).join(', ')} FROM ${table.quoted_path} LIMIT 100;`;
+        const dqlStatement = `SELECT ${table.columns
+          .filter(col => col.path_array.length === 0)
+          .map(el => el.quoted_column_name)
+          .join(', ')} FROM ${table.quoted_path} LIMIT 100;`;
 
         // format and copy
         navigator.clipboard.writeText(

--- a/src/constants/queries.ts
+++ b/src/constants/queries.ts
@@ -9,7 +9,8 @@ export const getTablesColumnsQuery = `
     QUOTE_IDENT(c.table_name) AS quoted_table_name,
     QUOTE_IDENT(c.column_name) AS quoted_column_name,
     c.data_type,
-    t.table_type
+    t.table_type,
+    column_details['path'] AS path_array
   FROM
     "information_schema"."columns" c
   JOIN

--- a/test/__mocks__/schemaTableColumn.ts
+++ b/test/__mocks__/schemaTableColumn.ts
@@ -9,6 +9,8 @@ export const schemaTableColumnMock = {
     'quoted_table_name',
     'quoted_column_name',
     'data_type',
+    'table_type',
+    'path_array',
   ],
   col_types: [4, 4, 4, 4, 4, 4, 4],
   rows: [
@@ -21,6 +23,7 @@ export const schemaTableColumnMock = {
       'version_num',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'gc',
@@ -31,6 +34,7 @@ export const schemaTableColumnMock = {
       'id',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'information_schema',
@@ -41,6 +45,7 @@ export const schemaTableColumnMock = {
       'character_repertoire',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'information_schema',
@@ -51,6 +56,7 @@ export const schemaTableColumnMock = {
       'character_set_catalog',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'new_schema',
@@ -61,6 +67,7 @@ export const schemaTableColumnMock = {
       'id',
       'bigint',
       'BASE TABLE',
+      [],
     ],
     [
       'new_schema',
@@ -71,6 +78,7 @@ export const schemaTableColumnMock = {
       'version_num',
       'text',
       'VIEW',
+      [],
     ],
     [
       'pg_catalog',
@@ -81,6 +89,7 @@ export const schemaTableColumnMock = {
       'amhandler',
       'regproc',
       'BASE TABLE',
+      [],
     ],
     [
       'pg_catalog',
@@ -91,6 +100,7 @@ export const schemaTableColumnMock = {
       'amname',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'sys',
@@ -101,6 +111,7 @@ export const schemaTableColumnMock = {
       'current_state',
       'text',
       'BASE TABLE',
+      [],
     ],
     [
       'sys',
@@ -111,6 +122,7 @@ export const schemaTableColumnMock = {
       'decisions',
       'object_array',
       'BASE TABLE',
+      [],
     ],
     [
       'sys',
@@ -121,6 +133,7 @@ export const schemaTableColumnMock = {
       "decisions['explanations']",
       'text_array_array',
       'BASE TABLE',
+      ['decisions'],
     ],
   ],
   rowcount: 10,


### PR DESCRIPTION
## Summary of changes
From ACs:
`- The DQL statement includes all column names (only top-level columns).`

This PR fixes the fact that DQL statement was including also non top-level columns.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2125
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
