### PR TITLE
Bump zustand from 4.4.7 to 5.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-11-26 - 0.18.2
+
+- Dependabot: bump zustand from 4.4.7 to 5.0.1.
+
 ## 2024-11-19 - 0.18.1
 
 - Fixed missing UsersTable export.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "author": "crate.io",
   "private": false,
   "type": "module",
@@ -70,7 +70,7 @@
     "web-vitals": "^2.1.0",
     "word-wrap": "^1.2.5",
     "zod": "^3.22.4",
-    "zustand": "^4.4.7"
+    "zustand": "5.0.1"
   },
   "scripts": {
     "start": "vite",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7575,11 +7575,6 @@ use-sidecar@^1.1.2:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
-
 use-sync-external-store@^1.2.0:
   version "1.2.2"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
@@ -7927,9 +7922,7 @@ zod@^3.22.4:
   resolved "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
-zustand@^4.4.7:
-  version "4.5.4"
-  resolved "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz#63abdd81edfb190bc61e0bbae045cc4d52158a05"
-  integrity sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==
-  dependencies:
-    use-sync-external-store "1.2.0"
+zustand@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz#2bdca5e4be172539558ce3974fe783174a48fdcf"
+  integrity sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==


### PR DESCRIPTION
## Summary of changes
This version bump is way easier and it has been done just to be 100% compatible with https://github.com/crate/cloud-ui/pull/2315.

## Checklist

- [x] Link to issue this PR refers to: n/a
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged. n/a
