### PR TITLE
JWT URL fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 2024-11-29 - 0.19.1
+
+- Fixed a bug where the wrong API URL was used for legacy clusters.
 - Fix flaky PolicyForm test.
 
 ## 2024-11-26 - 0.19.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crate.io/crate-gc-admin",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": "crate.io",
   "private": false,
   "type": "module",

--- a/src/state/jwtManager.ts
+++ b/src/state/jwtManager.ts
@@ -89,7 +89,7 @@ const useJWTManagerStore = create<JWTManagerStore>((set, get) => ({
   },
 
   getUrl: (identifier?: string) => {
-    let url = `${get().clusterUrl}/api/_sql?error_trace&types`;
+    let url = `${get().gcUrl}/api/_sql?error_trace&types`;
     if (get().isLocalConnection || get().isJWTEnabled) {
       url = `${get().clusterUrl}/_sql?error_trace&types`;
     }

--- a/src/swr/jwt/useSchemaTree.ts
+++ b/src/swr/jwt/useSchemaTree.ts
@@ -161,7 +161,7 @@ const QUERY = `
     SELECT
       table_schema,
       table_name,
-      ARRAY_AGG(QUOTE_IDENT(column_details['name']) || column_details['path']) column_paths,
+      ARRAY_AGG([QUOTE_IDENT(column_details['name'])] || column_details['path']) column_paths,
       ARRAY_AGG(data_type) data_types
     FROM "information_schema"."columns"
     GROUP BY table_schema, table_name


### PR DESCRIPTION
## Summary of changes
1) Fix typo in `jwtManager` where it picked the wrong URL
2) Made the schema tree SQL query compatible with older CrateDB versions. See: https://github.com/crate/cloud/issues/2290#issuecomment-2507074284

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2290
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
