### PR TITLE
FLOAT_VECTOR display

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,15 @@
 
 ## Unreleased
 
+## 2024-12-16 - 0.19.6
+
+- Add scrollbar to SQL results tab bar when many resultsets are returned.
+- Add support for FLOAT_VECTOR in SQL results.
+
 ## 2024-12-09 - 0.19.5
 
 - Improve spacing on schema tree buttons.
 - Fix case-sensitive error where schema refresh doesn't always occur.
-- Add scrollbar to SQL results tab bar when many resultsets are returned.
 
 ## 2024-12-06 - 0.19.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/SQLResults/TypeAwareValue/TypeAwareValue.test.tsx
+++ b/src/components/SQLResults/TypeAwareValue/TypeAwareValue.test.tsx
@@ -78,6 +78,13 @@ describe('The TypeAwareValue component', () => {
         'http://geojson.io/#data=data:application/json,{"coordinates":[[[16.344,48.137],[16.344,48.261],[16.462,48.261],[16.462,48.137],[16.344,48.137]]],"type":"Polygon"}',
       );
     });
+
+    it('will render a float vector', () => {
+      setup({ value: [1, 2], columnType: ColumnType.FLOAT_VECTOR });
+
+      const elem = screen.getByText('Array');
+      expect(elem.children[0]).toHaveTextContent('[2]');
+    });
   });
 
   describe('when a crate type is not specified', () => {

--- a/src/components/SQLResults/TypeAwareValue/TypeAwareValue.tsx
+++ b/src/components/SQLResults/TypeAwareValue/TypeAwareValue.tsx
@@ -65,6 +65,7 @@ function TypeAwareValue({
     case ColumnType.OBJECT:
     case ColumnType.ARRAY:
     case ColumnType.UNCHECKED_OBJECT:
+    case ColumnType.FLOAT_VECTOR:
       ret = <JSONTree json={value as object} />;
       break;
     case ColumnType.BOOLEAN:

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -32,6 +32,7 @@ export enum ColumnType {
   BIT = 25,
   JSON = 26,
   CHARACTER = 27,
+  FLOAT_VECTOR = 28,
   ARRAY = 100,
 }
 


### PR DESCRIPTION
## Summary of changes
Add the missing FLOAT_VECTOR data type to SQL results.


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2316
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
