### PR TITLE
Tabs scrollbar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Improve spacing on schema tree buttons.
 - Fix case-sensitive error where schema refresh doesn't always occur.
+- Add scrollbar to SQL results tab bar when many resultsets are returned.
 
 ## 2024-12-06 - 0.19.4
 

--- a/src/components/CrateTabsShad/CrateTabsShad.tsx
+++ b/src/components/CrateTabsShad/CrateTabsShad.tsx
@@ -48,15 +48,17 @@ function CrateTabsShad({
       value={activeTab}
       onValueChange={onTabChange}
     >
-      <TabsList
-        className={`min-h-10 ${hideWhenSingleTab && items.length === 1 ? 'hidden' : 'border-b'}`}
-      >
-        {items.map(item => (
-          <TabsTrigger key={item.key} value={item.key}>
-            {item.label}
-          </TabsTrigger>
-        ))}
-      </TabsList>
+      <div className="overflow-x-auto">
+        <TabsList
+          className={`min-h-10 ${hideWhenSingleTab && items.length === 1 ? 'hidden' : 'border-b'}`}
+        >
+          {items.map(item => (
+            <TabsTrigger key={item.key} value={item.key}>
+              {item.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </div>
       {items.map(item => (
         <TabsContent
           key={item.key}

--- a/src/components/SQLResults/SQLResults.tsx
+++ b/src/components/SQLResults/SQLResults.tsx
@@ -58,7 +58,7 @@ function SQLResults({ results, format }: Params) {
               })}
             >
               <div className="flex items-center justify-between gap-1.5 text-sm">
-                <span>Result {i}</span>
+                <span className="whitespace-nowrap">Result {i}</span>
                 {queryResult.status === 'EXECUTING' ? (
                   <Loader size={Loader.sizes.SMALL} />
                 ) : queryResult.status === 'ERROR' ? (


### PR DESCRIPTION
## Summary of changes
Displays a scrollbar when the number of tabs overflows the container. A smaller number of tabs that do not overflow are not affected.

![image](https://github.com/user-attachments/assets/6bb786b4-35c1-4d97-b4a1-75d66c994c9b)


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2287
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
