### PR TITLE
Prevent schema tree reload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2024-12-19 - 0.19.9
+
+- No longer refresh schema tree when navigating back to the SQL editor.
+
 ## 2024-12-18 - 0.19.8
 
 - Tidy CSS and fix scrolling issues.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "author": "cratedb",
   "private": false,
   "type": "module",
@@ -66,7 +66,7 @@
     "recharts": "^2.10.4",
     "rollup-preserve-directives": "^1.1.3",
     "sql-formatter": "^15.4.6",
-    "swr": "^2.2.4",
+    "swr": "^2.2.5",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "web-vitals": "^2.1.0",

--- a/src/swr/jwt/useSchemaTree.ts
+++ b/src/swr/jwt/useSchemaTree.ts
@@ -194,7 +194,7 @@ const useSchemaTree = (clusterId?: string) => {
   return useSWR<Schema[]>(
     [`/use-schema-tree/${clusterId}`, clusterId],
     ([url]: [string]) => swrJWTFetch(url, QUERY, postFetch),
-    {},
+    { revalidateIfStale: false, revalidateOnFocus: false },
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,7 +2973,7 @@ cli-width@^3.0.0:
 
 client-only@^0.0.1:
   version "0.0.1"
-  resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 cliui@^8.0.1:
@@ -7490,9 +7490,9 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-swr@^2.2.4:
+swr@^2.2.5:
   version "2.2.5"
-  resolved "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
   integrity sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==
   dependencies:
     client-only "^0.0.1"
@@ -7845,9 +7845,9 @@ use-sidecar@^1.1.2:
     tslib "^2.0.0"
 
 use-sync-external-store@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
-  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary of changes
- doesn't auto reload the schema tree when navigating around the app: this freezes the browser momentarility on very large datasets, e.g. turvo
- I also bumped the SWR version to ensure they are the same on gc-admin and the UI

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2321
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.
