### PR TITLE
Fix DDL/DQL copy to clipboard on Safari

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Grand Central Changelog
 
+## 2025-02-25 - 0.19.15
+
+- Fix DDL/DQL copy to clipboard on Safari.
+
 ## 2025-02-21 - 0.19.14
 
 - Add icon to Chip component and fix inconsistent usage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/SQLEditor/SQLEditorSchemaTree.tsx
+++ b/src/components/SQLEditor/SQLEditorSchemaTree.tsx
@@ -216,7 +216,13 @@ function SQLEditorSchemaTree() {
           const ddlStatement = `${ddlResult.data.rows[0][0]};`;
 
           // format and copy
-          navigator.clipboard.writeText(tryFormatSql(ddlStatement));
+          // need to use the setTimeout because API results
+          // are not considered a user-event
+          // and this causes it to fail on safari
+          setTimeout(async () => {
+            await navigator.clipboard.writeText(tryFormatSql(ddlStatement));
+          });
+
           showSuccessMessage('Copied');
         } else {
           showErrorMessage('Error genering DDL statement.');
@@ -230,7 +236,13 @@ function SQLEditorSchemaTree() {
           .join(', ')} FROM ${table.path.join('.')} LIMIT 100;`;
 
         // format and copy
-        navigator.clipboard.writeText(tryFormatSql(dqlStatement));
+        // need to use the setTimeout because API results
+        // are not considered a user-event
+        // and this causes it to fail on safari
+        setTimeout(async () => {
+          await navigator.clipboard.writeText(tryFormatSql(dqlStatement));
+        });
+
         showSuccessMessage('Copied');
       };
 


### PR DESCRIPTION
## Summary of changes
This PR fixes the copy DDL/DQL statements for Safari browser and also releases 0.19.15.

## Explanation
After analyzing the issue, I found out that Safari (differently than Chrome/Firefox) allows to use the clipboard API only for events that are triggered by the user. 
In this specific case, the copy DDL/DQL statement is:
- calling an API to generate the DDL/DQL statement
- copying using the clipboard API
Since an asynchronous context is not consider to be triggered by the user, this will fail on Safari (only).

[This article](https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/) explains why it's not working on Safari and how to handle it.

However, the proposed solution is not working for Firefox.

Handling different browsers directly in the code is a bit overkill in my opinion. I found in StackOverflow that a simple workaround is to wrap the clipboard API call in a `setTimeout`. I have tested in Chrome, Safari and also Firefox and it works as expected.

Note 1: another solution could be to use some compatibility package like [copy-to-clipboard](https://www.npmjs.com/package/copy-to-clipboard), but I will consider using that only if we have still some issues, since it will be another additional dependency.
Note 2: `CopyToClipboard` component is not affected by this Safari restriction, since it uses a button click event for copying the text. And I can't use it in this specific scenario because we have to make an API call before copying the text.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2469
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged. --> n/a
