### PR TITLE
Add additionalClickHandler to CopyToClipboard component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## 2025-04-21 - 0.20.0
+
 - Fix corrupted views not appearing in the schema tree.
+- Add additionalClickHandler to CopyToClipboard component.
 
 ## 2025-04-10 - 0.19.18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.19.18",
+  "version": "0.20.0",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -46,5 +46,15 @@ describe('the CopyToClipboard component', () => {
 
       expect(await screen.findByText('Copied')).toBeInTheDocument();
     });
+
+    it('calls the additionalClickHandler callback', async () => {
+      const additionalClickHandlerSpy = jest.fn();
+      const { user } = setup({ additionalClickHandler: additionalClickHandlerSpy });
+
+      await user.click(screen.getByTestId('copy-to-clipboard-button'));
+
+      expect(await screen.findByText('Copied')).toBeInTheDocument();
+      expect(additionalClickHandlerSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -5,6 +5,7 @@ export type CopyToClipboardProps = {
   successMessage?: string;
   textToCopy: string;
   testId?: string;
+  additionalClickHandler?: () => void;
 };
 
 function CopyToClipboard({
@@ -12,6 +13,7 @@ function CopyToClipboard({
   successMessage = 'Copied',
   textToCopy,
   testId = 'copy-to-clipboard-button',
+  additionalClickHandler,
 }: PropsWithChildren<CopyToClipboardProps>) {
   const { showSuccessMessage } = useMessage();
 
@@ -21,6 +23,10 @@ function CopyToClipboard({
       onClick={() => {
         navigator.clipboard.writeText(textToCopy);
         showSuccessMessage(successMessage);
+
+        if (additionalClickHandler) {
+          additionalClickHandler();
+        }
       }}
       type="button"
     >


### PR DESCRIPTION
## Summary of changes
⚠️ Merge AFTER https://github.com/crate/crate-gc-admin/pull/334 to do a single release.

This change is needed in order to track the events in `cloud-ui`.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2561
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
