### PR TITLE
Dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     open-pull-requests-limit: 10
-  - package-ecosystem: "docker" 
-    directory: "/"
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+  - package-ecosystem: 'docker'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Updated dependabot to ignore major version updates.
+- Dependabot: bump vite from 5.4.17 to 5.4.18.
+
 ## 2025-04-21 - 0.20.0
 
 - Fix corrupted views not appearing in the schema tree.

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "tailwindcss": "^3.4.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.3.3",
-    "vite": "^5.4.17",
+    "vite": "5.4.18",
     "vite-plugin-dts": "^4.3.0",
     "vite-plugin-eslint": "^1.8.1",
     "vite-tsconfig-paths": "^5.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8456,10 +8456,10 @@ vite-tsconfig-paths@^5.1.4:
     globrex "^0.1.2"
     tsconfck "^3.0.3"
 
-vite@^5.4.17:
-  version "5.4.17"
-  resolved "https://registry.npmjs.org/vite/-/vite-5.4.17.tgz#4bf61dd4cdbf64b0d6661f5dba76954cc81d5082"
-  integrity sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==
+vite@5.4.18:
+  version "5.4.18"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.18.tgz#b5af357f9d5ebb2e0c085779b7a37a77f09168a4"
+  integrity sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==
   dependencies:
     esbuild "^0.21.3"
     postcss "^8.4.43"


### PR DESCRIPTION
## Summary of changes
Updated dependabot to ignore major version updates. This hopefully prevents constantly being pestered to upgrade packages that don't need to be updated. However, we as developers now have a responsibility to ensure packages do not get too far out of date.

I propose we try this for a month and see what happens. Happy to hear alternate solutions.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2542
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
