### PR TITLE
Fix tabs bug, use tabs consistently

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2025-05-08 - 0.20.3
+
+- Fixed tabs bug.
+- Vite dependabot update.
+
 ## 2025-05-05 - 0.20.2
 
 - Making DataTable top pagination sticky to horizontal scrolling.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "author": "cratedb",
   "private": false,
   "type": "module",
@@ -135,7 +135,7 @@
     "tailwindcss": "^3.4.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.3.3",
-    "vite": "^5.4.18",
+    "vite": "^5.4.19",
     "vite-plugin-dts": "4.5.3",
     "vite-plugin-eslint": "^1.8.1",
     "vite-tsconfig-paths": "^5.1.4",

--- a/src/components/CrateTabsShad/CrateTabsShad.tsx
+++ b/src/components/CrateTabsShad/CrateTabsShad.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-
 import { cn } from 'utils';
 
 export type CrateTabShadProps = {
@@ -38,8 +37,13 @@ function CrateTabsShad({
 
   // ensure that the active tab is a valid option
   useEffect(() => {
-    setActiveTab(getDefaultTab());
-  }, [items]);
+    if (items) {
+      const keys = items.map(item => item.key);
+      if (!keys.includes(activeTab!)) {
+        setActiveTab(getDefaultTab());
+      }
+    }
+  }, [activeTab, items]);
 
   return (
     <Tabs
@@ -52,7 +56,11 @@ function CrateTabsShad({
       <div className={hideTabs ? '' : 'min-h-10 overflow-x-auto'}>
         <TabsList className={`min-h-10 ${hideTabs ? 'hidden' : 'border-b'}`}>
           {items.map(item => (
-            <TabsTrigger key={item.key} value={item.key}>
+            <TabsTrigger
+              key={item.key}
+              value={item.key}
+              className={item.key === activeTab ? 'text-crate-blue' : ''}
+            >
               {item.label}
             </TabsTrigger>
           ))}

--- a/src/routes/Tables/TableDetail.tsx
+++ b/src/routes/Tables/TableDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LeftOutlined } from '@ant-design/icons';
-import { Table, Tabs, Tag } from 'antd';
-import { Button, Heading } from 'components';
+import { Table, Tag } from 'antd';
+import { Button, CrateTabsShad, Heading } from 'components';
 import { format as formatSQL } from 'sql-formatter';
 import {
   useGetTableInformationQuery,
@@ -79,7 +79,7 @@ function TableDetail({
     {
       key: 'columns',
       label: 'Columns',
-      children: (
+      content: (
         <Table
           columns={columns}
           dataSource={activeTableInfo}
@@ -94,7 +94,7 @@ function TableDetail({
     tabs.push({
       key: 'SQL',
       label: 'SQL',
-      children: (
+      content: (
         <div className="">
           <pre>{createTableSQL}</pre>
         </div>
@@ -115,7 +115,7 @@ function TableDetail({
           <Heading level="h2">
             {activeTable.table_schema}.{activeTable.table_name}
           </Heading>
-          <Tabs defaultActiveKey="columns" items={tabs} />
+          <CrateTabsShad initialActiveTab="columns" items={tabs} hideWhenSingleTab />
           <div className="mt-4">
             <Link
               to={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -8666,10 +8666,10 @@ vite-tsconfig-paths@^5.1.4:
     globrex "^0.1.2"
     tsconfck "^3.0.3"
 
-vite@^5.4.18:
-  version "5.4.18"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.18.tgz#b5af357f9d5ebb2e0c085779b7a37a77f09168a4"
-  integrity sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==
+vite@^5.4.19:
+  version "5.4.19"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.19.tgz#20efd060410044b3ed555049418a5e7d1998f959"
+  integrity sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==
   dependencies:
     esbuild "^0.21.3"
     postcss "^8.4.43"


### PR DESCRIPTION
## Summary of changes
A few things:
- fixes a bug in the shad version of tabs where the tab would flick back to the first tab
- migrates the TableDetail component to use the shad version of tabs
- includes the most recent dependabot update
- does NOT remove the old `CloudTabs` component as we need this until we have tackled https://github.com/crate/cloud/issues/2580

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2595
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
