### PR TITLE
Add onChange to CrateTabsShad component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2025-05-08 - 0.20.4
+
+- Add onChange to CrateTabsShad component.
+
 ## 2025-05-08 - 0.20.3
 
 - Fixed tabs bug.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/CrateTabsShad/CrateTabsShad.test.tsx
+++ b/src/components/CrateTabsShad/CrateTabsShad.test.tsx
@@ -82,4 +82,30 @@ describe('The CrateTabsShad component', () => {
       expect(screen.getByTestId('tabs-container')).toHaveClass('flex');
     });
   });
+
+  describe('when changing tabs', () => {
+    it('calls the onChange prop with the new tab key', async () => {
+      const onChange = jest.fn();
+      const { user } = setup({ onChange });
+
+      const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+      await user.click(tab2);
+
+      expect(onChange).toHaveBeenCalledWith('tab2');
+    });
+
+    it('updates the active tab state', async () => {
+      const { user } = setup();
+
+      const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+      await user.click(tab2);
+
+      expect(screen.getAllByRole('tab')[0].getAttribute('aria-selected')).toBe(
+        'false',
+      );
+      expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe(
+        'true',
+      );
+    });
+  });
 });

--- a/src/components/CrateTabsShad/CrateTabsShad.tsx
+++ b/src/components/CrateTabsShad/CrateTabsShad.tsx
@@ -13,6 +13,7 @@ export type CrateTabsShadProps = {
   hideWhenSingleTab?: boolean; // don't show the tab bar if there is only one tab
   items: CrateTabShadProps[];
   stickyTabBar?: boolean; // make the tab bar sticky
+  onChange?: (key: string) => void; // callback when the active tab changes
 };
 
 function CrateTabsShad({
@@ -20,6 +21,7 @@ function CrateTabsShad({
   hideWhenSingleTab = false,
   items = [],
   stickyTabBar = false,
+  onChange,
 }: CrateTabsShadProps) {
   const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
   const hideTabs = hideWhenSingleTab && items.length === 1;
@@ -32,6 +34,9 @@ function CrateTabsShad({
   };
 
   const onTabChange = (value: string) => {
+    if (onChange) {
+      onChange(value);
+    }
     setActiveTab(value);
   };
 


### PR DESCRIPTION
## Summary of changes
Simply adding onChange on `CrateTabsShad` component in order to track events on tab change.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2562
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
