### PR TITLE
Removing whitespace prepended into pretty-printed query results strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2025-05-28 - 0.21.3
+
+- Removing whitespace prepended into pretty-printed query results strings.
+
 ## 2025-05-26 - 0.21.2
 
 - Exporting SQL Formatter utility file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -7,6 +7,6 @@ export const capitalizeFirstLetter = (str: string) => {
 export const wrapText = (text: string, wrapSize: number) => {
   return text
     .split('\n')
-    .map(line => wrap(line, { width: wrapSize }).trimEnd())
+    .map(line => wrap(line, { width: wrapSize, indent: '' }).trimEnd())
     .join('\n');
 };


### PR DESCRIPTION
## Summary of changes
[word-wrap](https://www.npmjs.com/package/word-wrap) is adding the leading whitespace that is causing the issue. This PR just remove the indent that is 2 whitespaces by default.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2598
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
