### PR TITLE
Migrate SQL Editor history from single-cluster to multi-cluster

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## 2025-06-03 - 0.21.5
+
 - Misc dependabot updates and node version bump.
+- Migrate SQL Editor history from single-cluster to multi-cluster.
 
 ## 2025-06-02 - 0.21.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/SQLHistory/SQLHistory.tsx
+++ b/src/components/SQLHistory/SQLHistory.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import { Modal, Table } from 'antd';
 import { CopyOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Button, CopyToClipboard, NoDataView } from 'components';
+import { SqlEditorHistoryEntry } from 'types/localStorage';
 
 type SQLHistoryProps = {
-  history: string[];
+  history: SqlEditorHistoryEntry[];
   showHistory: boolean;
   clearHistory: () => void;
   removeHistoryItem: (index: number) => void;
@@ -67,13 +68,13 @@ function SQLHistory({
   };
 
   const tableData = history
-    .map((query: string, index: number) => {
+    .map((historyEntry: SqlEditorHistoryEntry, index: number) => {
       return {
         key: `query_${index}`,
-        query: drawQuery(query, index),
+        query: drawQuery(historyEntry.query, index),
         manage: (
           <div className="flex gap-4">
-            <CopyToClipboard textToCopy={query}>
+            <CopyToClipboard textToCopy={historyEntry.query}>
               <CopyOutlined className="text-crate-blue" />
             </CopyToClipboard>
             <button

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -23,3 +23,6 @@ export const CRATEDB_PRIVILEGES_DOCS =
 
 export const CRATEDB_ERROR_CODES_DOCS =
   'https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#error-codes';
+
+// SQL Editor
+export const SQL_EDITOR_QUERIES_QUOTA = 100;

--- a/src/types/localStorage.ts
+++ b/src/types/localStorage.ts
@@ -1,0 +1,4 @@
+export type SqlEditorHistoryEntry = {
+  clusterId: string | undefined;
+  query: string;
+};


### PR DESCRIPTION
## Summary of changes
Idea behind this PR:
- having a unique history of 100 queries
- the new history array will contains object like `{ clusterId, query }`
- migrating the old "string-only" history into the new structure

I have not add any test since the "migration" code will probably be removed in a couple of months.

⚠️ I will update this PR do to the release next week, to avoid any conflicts.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2607
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
