### PR TITLE
Add dedicated clusterHealth store

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## 2025-06-06 - 0.21.6
+
 - Fix intermittent failing test.
 - Migrate crate-gc-admin env variables to vite specifications.
+- Migrate cluster health values from session store to new clusterHealth store.
 
 ## 2025-06-03 - 0.21.5
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 import { pathsToModuleNameMapper } from 'ts-jest';
 
-import tsconfig from './tsconfig.json' assert { type: 'json' };
+import tsconfig from './tsconfig.json' with { type: 'json' };
 
 export default {
   bail: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/ClusterHealthManager/ClusterHealthManager.tsx
+++ b/src/components/ClusterHealthManager/ClusterHealthManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import useSessionStore from 'state/session';
+import useClusterHealthStore from 'state/clusterHealth';
 import { useClusterNodeStatus } from 'src/swr/jwt';
 import { FSStats, LoadAverage, NodeStatusInfo } from 'types/cratedb';
 
@@ -10,7 +10,7 @@ export type ClusterHealthManagerProps = {
 export const STATS_PERIOD = 15 * 60 * 1000;
 
 function ClusterHealthManager({ clusterId }: ClusterHealthManagerProps) {
-  const { clusterHealth, setClusterHealth } = useSessionStore();
+  const { clusterHealth, setClusterHealth } = useClusterHealthStore();
   const { data: nodes } = useClusterNodeStatus(clusterId);
   const [prevNodeData, setPrevNodesData] = useState<NodeStatusInfo[] | []>();
 

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -12,14 +12,14 @@ import React, { useEffect, useState } from 'react';
 import { ClusterStatusColor, getClusterStatus } from 'utils/statusChecks';
 import Loader from 'components/Loader';
 import logo from '../../assets/logo.svg';
-import useSessionStore from 'state/session';
+import useClusterHealthStore from 'state/clusterHealth';
 import useJWTManagerStore from 'state/jwtManager';
 import { LOADER_SIZES } from 'components/Loader/LoaderConstants';
 
 function StatusBar() {
   const clusterId = useJWTManagerStore(state => state.clusterId);
   const [mobileVisible, setMobileVisible] = useState(false);
-  const { clusterHealth } = useSessionStore();
+  const { clusterHealth } = useClusterHealthStore();
   const { data: nodeStatus } = useClusterNodeStatus();
   const { data: currentUser } = useCurrentUser();
   const { data: cluster } = useClusterInfo(clusterId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { useJWTManagerStore };
 export * from './components';
 export * from './hooks';
 export * from './routes';
+export * from './state/clusterHealth';
 export * from './state/jwtManager';
 export * from './swr/jwt';
 

--- a/src/routes/Nodes/NodesMetrics.test.tsx
+++ b/src/routes/Nodes/NodesMetrics.test.tsx
@@ -5,7 +5,7 @@ import { NODE_STATUS_THRESHOLD } from 'constants/database';
 import prettyBytes from 'pretty-bytes';
 import { VERTICAL_PROGRESS_BARS } from 'components/VerticalProgress/VerticalProgress';
 import { formatNum } from 'utils';
-import useSessionStore from 'src/state/session';
+import useClusterHealthStore from 'src/state/clusterHealth';
 import { http, HttpResponse } from 'msw';
 import { useClusterNodeStatusMock } from 'test/__mocks__/useClusterNodeStatusMock';
 import { clusterNode } from 'test/__mocks__/nodes';
@@ -21,7 +21,7 @@ const waitForTableRender = async () => {
   await screen.findByRole('table');
 };
 
-const initialState = useSessionStore.getState();
+const initialState = useClusterHealthStore.getState();
 
 const changeStats = (fsUsedPercent: number, heapUsedPercent: number) => {
   // would be nicer to use structuredClone here...
@@ -390,7 +390,7 @@ describe('The Nodes component', () => {
         bps_read: 25,
       };
       beforeEach(async () => {
-        useSessionStore.setState({
+        useClusterHealthStore.setState({
           ...initialState,
           clusterHealth: { '': { fsStats: { [clusterNode.id]: stats }, load: [] } },
         });

--- a/src/routes/Nodes/NodesMetrics.tsx
+++ b/src/routes/Nodes/NodesMetrics.tsx
@@ -11,7 +11,7 @@ import {
   VerticalProgress,
 } from 'components';
 import { ColumnDef } from '@tanstack/react-table';
-import useSessionStore from 'src/state/session';
+import useClusterHealthStore from 'src/state/clusterHealth';
 import useJWTManagerStore from 'state/jwtManager';
 
 const MIN_COL_WIDTH = '170px';
@@ -19,7 +19,7 @@ const MIN_COL_WIDTH = '170px';
 function NodesMetrics() {
   const clusterId = useJWTManagerStore(state => state.clusterId);
   const isLocalConnection = useJWTManagerStore(state => state.isLocalConnection);
-  const { clusterHealth } = useSessionStore();
+  const { clusterHealth } = useClusterHealthStore();
 
   const { data: nodes } = useClusterNodeStatus(clusterId);
   const { data: cluster } = useClusterInfo(clusterId);

--- a/src/routes/Overview/Overview.tsx
+++ b/src/routes/Overview/Overview.tsx
@@ -4,12 +4,12 @@ import { Statistic, Tag } from 'antd';
 import { STATS_PERIOD } from 'components/ClusterHealthManager/ClusterHealthManager';
 import { ClusterStatusColor, getClusterStatus } from 'utils/statusChecks';
 import { formatHumanReadable, formatNum } from 'utils/numbers';
-import useSessionStore from 'state/session';
+import useClusterHealthStore from 'state/clusterHealth';
 import useJWTManagerStore from 'state/jwtManager';
 
 function Overview() {
   const clusterId = useJWTManagerStore(state => state.clusterId);
-  const { clusterHealth } = useSessionStore();
+  const { clusterHealth } = useClusterHealthStore();
 
   const { data: cluster } = useClusterInfo(clusterId);
   const { data: allocations } = useAllocations();

--- a/src/state/clusterHealth.ts
+++ b/src/state/clusterHealth.ts
@@ -1,0 +1,36 @@
+// the state in this file is not persisted to localStorage
+// use this for cluster health management only
+
+import { create } from 'zustand';
+import { FSStats, LoadAverage } from 'types/cratedb';
+
+type ClusterHealth = {
+  load: LoadAverage[];
+  fsStats: { [key: string]: FSStats };
+};
+
+type ClusterHealthStore = {
+  clusterHealth: Record<string, ClusterHealth>;
+  setClusterHealth: (clusterId: string, health: ClusterHealth) => void;
+};
+
+const initialState = {
+  clusterHealth: {},
+};
+
+const useClusterHealthStore = create<ClusterHealthStore>(set => ({
+  ...initialState,
+
+  setClusterHealth: (clusterId: string, health: ClusterHealth) => {
+    set(state => {
+      return {
+        clusterHealth: {
+          ...state.clusterHealth,
+          [clusterId]: health,
+        },
+      };
+    });
+  },
+}));
+
+export default useClusterHealthStore;

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -2,17 +2,11 @@
 // currently used for API error notifications only
 
 import { create } from 'zustand';
-import { FSStats, LoadAverage } from 'types/cratedb';
 
 type Notification = {
   type?: NotificationType;
   message: string;
   description?: string | React.ReactElement;
-};
-
-type ClusterHealth = {
-  load: LoadAverage[];
-  fsStats: { [key: string]: FSStats };
 };
 
 type SessionStore = {
@@ -25,10 +19,6 @@ type SessionStore = {
     description?: string,
   ) => void;
 
-  // health
-  clusterHealth: Record<string, ClusterHealth>;
-  setClusterHealth: (clusterId: string, health: ClusterHealth) => void;
-
   // table results format
   tableResultsFormatPretty: boolean;
   setTableResultsFormatPretty: (pretty: boolean) => void;
@@ -40,7 +30,6 @@ type SessionStore = {
 
 const initialState = {
   notification: null,
-  clusterHealth: {},
   tableResultsFormatPretty: true,
   showErrorTrace: false,
 };
@@ -59,16 +48,6 @@ const useSessionStore = create<SessionStore>(set => ({
     description?: string,
   ) => {
     set({ notification: { type, message, description } });
-  },
-  setClusterHealth: (clusterId: string, health: ClusterHealth) => {
-    set(state => {
-      return {
-        clusterHealth: {
-          ...state.clusterHealth,
-          [clusterId]: health,
-        },
-      };
-    });
   },
   setShowErrorTrace: (showErrorTrace: boolean) => {
     set({ showErrorTrace });


### PR DESCRIPTION
## Summary of changes
Storing frequently changing data in the `session` store meant components using those stores would re-render on change. Here I have split out the health values to a dedicated `clusterHealth` store which will can update more frequently as it is only used by component reliant on health data.

Also, note the `jest.config.js` to comply with the latest node version.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2641
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
