### PR TITLE
Revert change in tailwind config and update button disabled border

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2025-06-27 - 0.22.2
+
+- Revert change in tailwind config and update button disabled border.
+
 ## 2025-06-27 - 0.22.1
 
 - Make Buttons consitent.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/components/Button/useButtonStyles.ts
+++ b/src/components/Button/useButtonStyles.ts
@@ -90,7 +90,7 @@ function useButtonStyles({
       },
       {
         // disabled
-        'border-crate-border-mid': !kindIsTertiary && !kindIsSecondary && disabled,
+        'border-crate-border-light': !kindIsTertiary && !kindIsSecondary && disabled,
         'bg-neutral-100': kindIsPrimary && disabled,
         'text-neutral-400': disabled,
         'cursor-not-allowed': disabled,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
         'crate-green-1': '#9BF1AD',
         'crate-body-background': '#F1F1F1',
         'crate-border-dark': '#525252', // tailwind neutral-600
-        'crate-border-mid': '#d4d4d4', // tailwind neutral-300
+        'crate-border-mid': '#A3A3A3', // tailwind neutral-400
         'crate-border-light': '#D4D4D4', // tailwind neutral-300
         'crate-form-disabled': '#f5f5f5',
         'crate-gray30': '#777',


### PR DESCRIPTION
## Summary of changes
I found out that, after latest change, `crate-border-mid` and `crate-border-light` were configured with the same color. This is of course wrong and causes some issues in cloud-ui, that's why I have reverted this change on the configuration and updated the button to use `crate-border-light` instead of `crate-border-mid`.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2623
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
