### PR TITLE
Update prettierignore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 ## Summary of changes
 
+
 ## Checklist
 
 - [ ] Link to issue this PR refers to:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 *.json
+*.md
+*.yaml
+*.yml


### PR DESCRIPTION
## Summary of changes
The previous `prettier` update was incorrectly including `yaml` and `markdown` files.  This tiny PR updates the `.prettierignore` file and reverts a formatting change. No need to update the `CHANGES` file as the previous entry covers this change.

## Checklist

- [ ] Link to issue this PR refers to: n/a
- [ ] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
