### PR TITLE
Add error messages related to node status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add error messages related to node status.
+
 ## 2026-02-24 - 0.23.2
 
 - Parallelize GHA workflow steps

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -5,7 +5,7 @@ import {
   generateData,
 } from './test/dataTableTestUtils';
 import { DEFAULT_ELEMENTS_PER_PAGE, DataTable, DataTableProps } from './DataTable';
-import { render, screen, waitFor } from 'test/testUtils';
+import { render, screen, waitFor, within } from 'test/testUtils';
 
 const data = generateData();
 const columns = colDef;
@@ -160,6 +160,33 @@ describe('The DataTable component', () => {
       checkElementInTable(elements[0]);
       expect(screen.getByText('ERROR_MESSAGE')).toBeInTheDocument();
       checkElementInTable(elements[1]);
+    });
+  });
+
+  describe('when the row has an error message with docs link', () => {
+    const elements: SampleDataWithError[] | SampleData[] = generateData(2);
+    elements[0] = {
+      ...elements[0],
+      errorMessages: [
+        {
+          message: 'ERROR_MESSAGE',
+          status: 'CRITICAL',
+          docs_link: 'https://example.com',
+        },
+      ],
+    } as SampleDataWithError;
+
+    it('should render the error messages in a row below the main row', async () => {
+      setup({ data: elements });
+
+      await waitForRender();
+
+      checkElementInTable(elements[0]);
+      expect(screen.getByText('ERROR_MESSAGE')).toBeInTheDocument();
+      const link = screen.getByRole('link');
+      expect(link).toBeInTheDocument();
+      expect(within(link).getByText('Learn more')).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'https://example.com');
     });
   });
 

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -5,7 +5,7 @@ import {
   generateData,
 } from './test/dataTableTestUtils';
 import { DEFAULT_ELEMENTS_PER_PAGE, DataTable, DataTableProps } from './DataTable';
-import { render, screen } from 'test/testUtils';
+import { render, screen, waitFor } from 'test/testUtils';
 
 const data = generateData();
 const columns = colDef;
@@ -19,6 +19,12 @@ const setup = (props: Partial<DataTableProps<SampleData, unknown>> = {}) => {
   const combinedProps = { ...defaultProps, ...props };
 
   return render(<DataTable {...combinedProps} />);
+};
+
+const waitForRender = async () => {
+  await waitFor(() => {
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
 };
 
 // Utility function to check that the whole element is in the table
@@ -37,10 +43,9 @@ const getNumberOfRows = (container: HTMLElement) => {
 };
 
 describe('The DataTable component', () => {
-  it('renders a table', () => {
+  it('renders a table', async () => {
     setup();
-
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    waitForRender();
   });
 
   describe('the columns', () => {
@@ -86,6 +91,8 @@ describe('The DataTable component', () => {
       it('should toggle sort if clicked', async () => {
         const { user } = setup();
 
+        waitForRender();
+
         // Before clicking it should be not sorted
         expect(screen.getByTestId('head_col_name')).toHaveAttribute(
           'data-sorting',
@@ -128,14 +135,14 @@ describe('The DataTable component', () => {
     });
   });
 
-  describe('when the row has a error messages', () => {
+  describe('when the row has an error message', () => {
     const elements: SampleDataWithError[] | SampleData[] = generateData(2);
     elements[0] = {
       ...elements[0],
       errorMessages: [{ message: 'ERROR_MESSAGE', status: 'CRITICAL' }],
     } as SampleDataWithError;
 
-    it('should render the error messages in a row bellow the main row', () => {
+    it('should render the error messages in a row below the main row', () => {
       setup({ data: elements });
 
       checkElementInTable(elements[0]);

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,5 +1,10 @@
+import {
+  SampleData,
+  SampleDataWithError,
+  colDef,
+  generateData,
+} from './test/dataTableTestUtils';
 import { DEFAULT_ELEMENTS_PER_PAGE, DataTable, DataTableProps } from './DataTable';
-import { SampleData, colDef, generateData } from './test/dataTableTestUtils';
 import { render, screen } from 'test/testUtils';
 
 const data = generateData();
@@ -120,6 +125,22 @@ describe('The DataTable component', () => {
           'desc',
         );
       });
+    });
+  });
+
+  describe('when the row has a error messages', () => {
+    const elements: SampleDataWithError[] | SampleData[] = generateData(2);
+    elements[0] = {
+      ...elements[0],
+      errorMessages: [{ message: 'ERROR_MESSAGE', status: 'CRITICAL' }],
+    } as SampleDataWithError;
+
+    it('should render the error messages in a row bellow the main row', () => {
+      setup({ data: elements });
+
+      checkElementInTable(elements[0]);
+      expect(screen.getByText('ERROR_MESSAGE')).toBeInTheDocument();
+      checkElementInTable(elements[1]);
     });
   });
 

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -45,22 +45,26 @@ const getNumberOfRows = (container: HTMLElement) => {
 describe('The DataTable component', () => {
   it('renders a table', async () => {
     setup();
-    waitForRender();
+    await waitForRender();
   });
 
   describe('the columns', () => {
     const firstElement = data[0];
 
-    it('uses the specified column header', () => {
+    it('uses the specified column header', async () => {
       setup({ data: [firstElement] });
+
+      await waitForRender();
 
       columns.forEach(col => {
         expect(screen.getByText(col.header as string)).toBeInTheDocument();
       });
     });
 
-    it('uses the specified column value', () => {
+    it('uses the specified column value', async () => {
       setup({ data: [firstElement] });
+
+      await waitForRender();
 
       expect(screen.getByRole('table')).toBeInTheDocument();
 
@@ -79,11 +83,15 @@ describe('The DataTable component', () => {
           ],
         });
 
+        await waitForRender();
+
         expect(screen.queryByTestId('sorting_button_name')).not.toBeInTheDocument();
       });
 
-      it('should be present if enabledSorting = true', () => {
+      it('should be present if enabledSorting = true', async () => {
         setup();
+
+        await waitForRender();
 
         expect(screen.getByTestId('sorting_button_name')).toBeInTheDocument();
       });
@@ -91,7 +99,7 @@ describe('The DataTable component', () => {
       it('should toggle sort if clicked', async () => {
         const { user } = setup();
 
-        waitForRender();
+        await waitForRender();
 
         // Before clicking it should be not sorted
         expect(screen.getByTestId('head_col_name')).toHaveAttribute(
@@ -126,6 +134,8 @@ describe('The DataTable component', () => {
           ],
         });
 
+        await waitForRender();
+
         // Before clicking it should be not sorted
         expect(screen.getByTestId('head_col_name')).toHaveAttribute(
           'data-sorting',
@@ -142,8 +152,10 @@ describe('The DataTable component', () => {
       errorMessages: [{ message: 'ERROR_MESSAGE', status: 'CRITICAL' }],
     } as SampleDataWithError;
 
-    it('should render the error messages in a row below the main row', () => {
+    it('should render the error messages in a row below the main row', async () => {
       setup({ data: elements });
+
+      await waitForRender();
 
       checkElementInTable(elements[0]);
       expect(screen.getByText('ERROR_MESSAGE')).toBeInTheDocument();
@@ -152,8 +164,10 @@ describe('The DataTable component', () => {
   });
 
   describe('the pagination', () => {
-    it('should display the pagination where current page is the first', () => {
+    it('should display the pagination where current page is the first', async () => {
       setup();
+
+      await waitForRender();
 
       expect(screen.getByTestId('datatable-pagination')).toBeInTheDocument();
       // Prev arrow should be disabled, next arrow should be enabled
@@ -171,38 +185,46 @@ describe('The DataTable component', () => {
       );
     });
 
-    it('should show "DEFAULT_ELEMENTS_PER_PAGE" elements per page by default', () => {
+    it('should show "DEFAULT_ELEMENTS_PER_PAGE" elements per page by default', async () => {
       const { container } = setup();
+
+      await waitForRender();
 
       // There should be only DEFAULT_ELEMENTS_PER_PAGE table rows per page
       expect(getNumberOfRows(container)).toBe(DEFAULT_ELEMENTS_PER_PAGE);
     });
 
-    it('should show the specified elements per page by passing the prop', () => {
+    it('should show the specified elements per page by passing the prop', async () => {
       const { container } = setup({
         elementsPerPage: 10,
       });
+
+      await waitForRender();
 
       // There should be only 10 table rows per page
       expect(getNumberOfRows(container)).toBe(10);
     });
 
     describe('when hidePaginationWhenSinglePage is set', () => {
-      it('does not display pagination if there is only one page', () => {
+      it('does not display pagination if there is only one page', async () => {
         setup({
           data: generateData(1),
           hidePaginationWhenSinglePage: true,
         });
+
+        await waitForRender();
 
         expect(screen.queryByTestId('datatable-pagination')).not.toBeInTheDocument();
       });
     });
 
     describe('when hidePaginationPageSize is set', () => {
-      it('does not display the page size selector', () => {
+      it('does not display the page size selector', async () => {
         setup({
           hidePaginationPageSize: true,
         });
+
+        await waitForRender();
 
         expect(screen.queryByTestId('datatable-pagination')).toBeInTheDocument();
 
@@ -213,10 +235,12 @@ describe('The DataTable component', () => {
     });
 
     describe('when paginationContent is set', () => {
-      it('displays the custom pagination content', () => {
+      it('displays the custom pagination content', async () => {
         setup({
           paginationContent: <div data-testid="custom-pagination-content" />,
         });
+
+        await waitForRender();
 
         expect(screen.getByTestId('custom-pagination-content')).toBeInTheDocument();
       });
@@ -224,45 +248,55 @@ describe('The DataTable component', () => {
   });
 
   describe('when stickyHeader is set', () => {
-    it('applies the CSS classes to make the table header sticky', () => {
+    it('applies the CSS classes to make the table header sticky', async () => {
       setup({
         stickyHeader: true,
       });
+
+      await waitForRender();
 
       expect(screen.getByTestId('head_col_name')).toHaveClass('sticky');
     });
   });
 
   describe('when table is empty', () => {
-    it('should show "No results" label', () => {
+    it('should show "No results" label', async () => {
       setup({
         data: [],
       });
+
+      await waitForRender();
 
       expect(screen.getByText(/No results/)).toBeInTheDocument();
     });
 
-    it('should show custom no result label if passing noResultsLabel prop', () => {
+    it('should show custom no result label if passing noResultsLabel prop', async () => {
       setup({
         data: [],
         noResultsLabel: 'CUSTOM_NO_RESULT',
       });
+
+      await waitForRender();
 
       expect(screen.getByText('CUSTOM_NO_RESULT')).toBeInTheDocument();
     });
   });
 
   describe('the filters', () => {
-    it('should be hidden by default', () => {
+    it('should be hidden by default', async () => {
       setup();
+
+      await waitForRender();
 
       expect(screen.queryByTestId('datatable-filters')).not.toBeInTheDocument();
     });
 
-    it('should render only filters for columns with enableColumnFilter = true', () => {
+    it('should render only filters for columns with enableColumnFilter = true', async () => {
       setup({
         enableFilters: true,
       });
+
+      await waitForRender();
 
       expect(screen.getByTestId('datatable-filter-name')).toBeInTheDocument();
       expect(
@@ -271,10 +305,12 @@ describe('The DataTable component', () => {
     });
 
     describe('when enableFilters = true', () => {
-      it('filters should be present', () => {
+      it('filters should be present', async () => {
         setup({
           enableFilters: true,
         });
+
+        await waitForRender();
 
         expect(screen.getByTestId('datatable-filters')).toBeInTheDocument();
       });
@@ -292,21 +328,25 @@ describe('The DataTable component', () => {
       });
 
       describe('the search box', () => {
-        it('should be hidden by default', () => {
+        it('should be hidden by default', async () => {
           setup({
             enableFilters: true,
           });
+
+          await waitForRender();
 
           expect(
             screen.queryByTestId('datatable-searchbox'),
           ).not.toBeInTheDocument();
         });
 
-        it('should be present if enableSearchBox = true', () => {
+        it('should be present if enableSearchBox = true', async () => {
           setup({
             enableFilters: true,
             enableSearchBox: true,
           });
+
+          await waitForRender();
 
           expect(screen.queryByTestId('datatable-searchbox')).toBeInTheDocument();
         });
@@ -330,15 +370,17 @@ describe('The DataTable component', () => {
   });
 
   describe('when the pagination is disabled', () => {
-    it('does not display the pagination', () => {
+    it('does not display the pagination', async () => {
       setup({ disablePagination: true });
+
+      await waitForRender();
 
       expect(screen.queryByTestId('datatable-pagination')).not.toBeInTheDocument();
     });
   });
 
   describe('when passing in a custom table header', () => {
-    it('renders the custom header, not the standard one', () => {
+    it('renders the custom header, not the standard one', async () => {
       setup({
         customTableHeader: (
           <thead data-testid="custom-table-header">
@@ -350,6 +392,8 @@ describe('The DataTable component', () => {
           </thead>
         ),
       });
+
+      await waitForRender();
 
       expect(screen.getByTestId('custom-table-header')).toBeInTheDocument();
       expect(screen.getAllByRole('columnheader').length).toBe(3);

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -340,6 +340,15 @@ export function DataTable<TData, TValue>({
                               className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
                             >
                               {msg.message}
+                              {msg.docs_link && (
+                                <a
+                                  href={msg.docs_link}
+                                  target="_blank"
+                                  className="ml-1 text-xs"
+                                >
+                                  Learn more
+                                </a>
+                              )}
                             </div>
                           ),
                         )}

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -25,6 +25,8 @@ import type {
   Row,
   TableOptions,
 } from '@tanstack/react-table';
+import { ErrorMessage } from 'types/cratedb';
+import TableRowWithNote from 'components/TableRowWithNote';
 
 export const DEFAULT_ELEMENTS_PER_PAGE = 10;
 
@@ -109,6 +111,7 @@ export function DataTable<TData, TValue>({
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
     getFiltersFromQuery(location?.search, columns),
   );
+  const [hoveredRowGroup, setHoveredRowGroup] = useState<string | null>(null);
 
   const getReactTableOptions = (): TableOptions<TData> => {
     const options: TableOptions<TData> = {
@@ -309,40 +312,52 @@ export function DataTable<TData, TValue>({
         <Table.Body>
           {table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map(row => {
-              const hasErrorMessages = !!(row.original as any).errorMessages;
-              return (
-              <React.Fragment key={row.id}>
-              <Table.Row
-                key={row.id}
-                data-state={row.getIsSelected() && 'selected'}
-                data-row-key={row.id}
-                className={cn(
-                  "hover:bg-table-row-hover",
-                  hasErrorMessages && "border-b-0"
-                )}
-              >
-                {row.getVisibleCells().map(cell => (
-                  <Table.Cell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Table.Cell>
-                ))}
-              </Table.Row>
-              {hasErrorMessages && (
-                <Table.Row className="hover:bg-table-row-hover">
-                  <Table.Cell colSpan={row.getVisibleCells().length} className='p-0'>
-                    {(row.original as any).errorMessages.map((msg: any, index: number) => (
-                      <div
-                        key={index}
-                        className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
-                      >
-                        {msg.message}
-                      </div>
+              const rowOriginal = row.original as TData & { errorMessages?: ErrorMessage[] };
+              const hasErrorMessages = !!rowOriginal.errorMessages;
+              if (hasErrorMessages) {
+                return (
+                  <TableRowWithNote
+                    rowId={row.id}
+                    cells={
+                      row.getVisibleCells().map(cell => (
+                        <Table.Cell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </Table.Cell>
+                      ))
+                    }
+                    note={
+                      <Table.Cell colSpan={row.getVisibleCells().length} className='p-0'>
+                        {rowOriginal.errorMessages.map((msg: ErrorMessage, index: number) => (
+                          <div
+                            key={index}
+                            className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
+                          >
+                             {msg.message}
+                          </div>
+                        ))}
+                     </Table.Cell>
+                    }
+                    dataState={row.getIsSelected() ? 'selected' : ''}
+                    hoveredRowGroup={hoveredRowGroup}
+                    setHoveredRowGroup={setHoveredRowGroup}
+                  />
+                );
+              } else {
+                return (
+                  <Table.Row
+                    key={row.id}
+                    data-state={row.getIsSelected() && 'selected'}
+                    data-row-key={row.id}
+                  >
+                    {row.getVisibleCells().map(cell => (
+                      <Table.Cell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </Table.Cell>
                     ))}
-                  </Table.Cell>
-                </Table.Row>
-              )}
-              </React.Fragment>
-            )})
+                  </Table.Row>
+                );
+              }
+          })
           ) : (
             <Table.Row className="hover:bg-transparent">
               <Table.Cell

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -68,6 +68,17 @@ const getFiltersFromQuery = <TData, TValue>(
   return columnFilters;
 };
 
+const getStatusClass = (status: string) => {
+  switch (status) {
+    case 'CRITICAL':
+      return 'border-red-400';
+    case 'WARNING':
+      return 'border-amber-400';
+    default:
+      return '';
+  }
+};
+
 export function DataTable<TData, TValue>({
   columns,
   data,
@@ -297,11 +308,18 @@ export function DataTable<TData, TValue>({
 
         <Table.Body>
           {table.getRowModel().rows?.length ? (
-            table.getRowModel().rows.map(row => (
+            table.getRowModel().rows.map(row => {
+              const hasErrorMessages = !!(row.original as any).errorMessages;
+              return (
+              <React.Fragment key={row.id}>
               <Table.Row
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
                 data-row-key={row.id}
+                className={cn(
+                  "hover:bg-table-row-hover",
+                  hasErrorMessages && "border-b-0"
+                )}
               >
                 {row.getVisibleCells().map(cell => (
                   <Table.Cell key={cell.id}>
@@ -309,7 +327,22 @@ export function DataTable<TData, TValue>({
                   </Table.Cell>
                 ))}
               </Table.Row>
-            ))
+              {hasErrorMessages && (
+                <Table.Row className="hover:bg-table-row-hover">
+                  <Table.Cell colSpan={row.getVisibleCells().length} className='p-0'>
+                    {(row.original as any).errorMessages.map((msg: any, index: number) => (
+                      <div
+                        key={index}
+                        className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
+                      >
+                        {msg.message}
+                      </div>
+                    ))}
+                  </Table.Cell>
+                </Table.Row>
+              )}
+              </React.Fragment>
+            )})
           ) : (
             <Table.Row className="hover:bg-transparent">
               <Table.Cell

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -15,8 +15,10 @@ import { useEffect, useState } from 'react';
 import { arrIncludesElement } from 'utils';
 import * as React from 'react';
 import { cn } from 'utils';
+import TableRowWithNote from 'components/TableRowWithNote';
 import { Button, Pagination, Table } from 'components';
 import DataTableFilters from './DataTableFilters';
+import { ErrorMessage } from 'types/cratedb';
 import type {
   ColumnFiltersState,
   Header,
@@ -25,8 +27,6 @@ import type {
   Row,
   TableOptions,
 } from '@tanstack/react-table';
-import { ErrorMessage } from 'types/cratedb';
-import TableRowWithNote from 'components/TableRowWithNote';
 
 export const DEFAULT_ELEMENTS_PER_PAGE = 10;
 
@@ -312,30 +312,37 @@ export function DataTable<TData, TValue>({
         <Table.Body>
           {table.getRowModel().rows?.length ? (
             table.getRowModel().rows.map(row => {
-              const rowOriginal = row.original as TData & { errorMessages?: ErrorMessage[] };
-              const hasErrorMessages = !!rowOriginal.errorMessages;
-              if (hasErrorMessages) {
+              const rowOriginal = row.original as TData & {
+                errorMessages?: ErrorMessage[];
+              };
+              if (
+                rowOriginal.errorMessages &&
+                rowOriginal.errorMessages.length > 0
+              ) {
                 return (
                   <TableRowWithNote
                     rowId={row.id}
-                    cells={
-                      row.getVisibleCells().map(cell => (
-                        <Table.Cell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </Table.Cell>
-                      ))
-                    }
+                    cells={row.getVisibleCells().map(cell => (
+                      <Table.Cell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </Table.Cell>
+                    ))}
                     note={
-                      <Table.Cell colSpan={row.getVisibleCells().length} className='p-0'>
-                        {rowOriginal.errorMessages.map((msg: ErrorMessage, index: number) => (
-                          <div
-                            key={index}
-                            className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
-                          >
-                             {msg.message}
-                          </div>
-                        ))}
-                     </Table.Cell>
+                      <Table.Cell
+                        colSpan={row.getVisibleCells().length}
+                        className="p-0"
+                      >
+                        {rowOriginal.errorMessages?.map(
+                          (msg: ErrorMessage, index: number) => (
+                            <div
+                              key={index}
+                              className={`text-neutral-500 border-l-[6px] pl-1 mb-2 rounded-md ${getStatusClass(msg.status)}`}
+                            >
+                              {msg.message}
+                            </div>
+                          ),
+                        )}
+                      </Table.Cell>
                     }
                     dataState={row.getIsSelected() ? 'selected' : ''}
                     hoveredRowGroup={hoveredRowGroup}
@@ -357,7 +364,7 @@ export function DataTable<TData, TValue>({
                   </Table.Row>
                 );
               }
-          })
+            })
           ) : (
             <Table.Row className="hover:bg-transparent">
               <Table.Cell

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -321,6 +321,7 @@ export function DataTable<TData, TValue>({
               ) {
                 return (
                   <TableRowWithNote
+                    key={row.id}
                     rowId={row.id}
                     cells={row.getVisibleCells().map(cell => (
                       <Table.Cell key={cell.id}>

--- a/src/components/DataTable/test/dataTableTestUtils.ts
+++ b/src/components/DataTable/test/dataTableTestUtils.ts
@@ -1,8 +1,13 @@
 import { ColumnDef } from '@tanstack/react-table';
+import { ErrorMessage } from 'types/cratedb';
 
 export type SampleData = {
   name: string;
   surname: string;
+};
+
+export type SampleDataWithError = SampleData & {
+  errorMessages: ErrorMessage[];
 };
 
 export const generateData = (numberOfElements: number = 250): SampleData[] => {

--- a/src/components/TableRowWithNote/TableRowWithNote.test.tsx
+++ b/src/components/TableRowWithNote/TableRowWithNote.test.tsx
@@ -8,7 +8,7 @@ const defaultProps: TableRowWithNoteProps = {
   rowId: '1',
   cells: [<td key="cell1">Cell 1</td>],
   note: <td>Note content</td>,
-  dataState: 'selected',
+  dataState: '',
   hoveredRowGroup: null,
   setHoveredRowGroup: setHoveredRowGroupMock,
 };

--- a/src/components/TableRowWithNote/TableRowWithNote.test.tsx
+++ b/src/components/TableRowWithNote/TableRowWithNote.test.tsx
@@ -1,0 +1,92 @@
+import TableRowWithNote, { TableRowWithNoteProps } from './TableRowWithNote';
+import { render, screen, within, fireEvent } from 'test/testUtils';
+import Table from 'components/Table';
+
+const setHoveredRowGroupMock = jest.fn();
+
+const defaultProps: TableRowWithNoteProps = {
+  rowId: '1',
+  cells: [<td key="cell1">Cell 1</td>],
+  note: <td>Note content</td>,
+  dataState: 'selected',
+  hoveredRowGroup: null,
+  setHoveredRowGroup: setHoveredRowGroupMock,
+};
+
+const setup = (props: Partial<TableRowWithNoteProps> = {}) => {
+  const combinedProps = { ...defaultProps, ...props };
+
+  return render(
+    <Table>
+      <Table.Body>
+        <TableRowWithNote {...combinedProps} />
+      </Table.Body>
+    </Table>,
+  );
+};
+
+describe('The TableRowWithNote component', () => {
+  it('renders the cells in the first row', () => {
+    setup({
+      ...defaultProps,
+      cells: [<td key="cell1">Cell 1</td>, <td key="cell2">Cell 2</td>],
+    });
+
+    expect(screen.getByText('Cell 1')).toBeInTheDocument();
+    expect(screen.getByText('Cell 2')).toBeInTheDocument();
+  });
+
+  it('renders the note in the second row', () => {
+    setup();
+
+    const noteRow = screen.getByTestId('note-row');
+    expect(noteRow).toBeInTheDocument();
+    expect(within(noteRow).getByText('Note content')).toBeInTheDocument();
+  });
+
+  it('applies the hovered style to both rows when hoveredRowGroup matches the rowId', () => {
+    setup({ ...defaultProps, hoveredRowGroup: '1' });
+
+    const firstRow = screen.getByText('Cell 1').closest('tr');
+    const noteRow = screen.getByTestId('note-row');
+
+    expect(firstRow).toHaveClass('bg-table-row-hover');
+    expect(noteRow).toHaveClass('bg-table-row-hover');
+  });
+
+  it('calls setHoveredRowGroup with the rowId on mouse enter on the first row', async () => {
+    const { user } = setup();
+
+    const firstRow = screen.getByText('Cell 1').closest('tr');
+    await user.hover(firstRow!);
+
+    expect(setHoveredRowGroupMock).toHaveBeenCalledWith('1');
+  });
+
+  it('calls setHoveredRowGroup with the rowId on mouse enter on the note row', async () => {
+    const { user } = setup();
+
+    const noteRow = screen.getByTestId('note-row');
+    await user.hover(noteRow!);
+
+    expect(setHoveredRowGroupMock).toHaveBeenCalledWith('1');
+  });
+
+  it('calls setHoveredRowGroup with null on mouse leave on the first row', () => {
+    setup();
+
+    const firstRow = screen.getByText('Cell 1').closest('tr');
+    fireEvent.mouseLeave(firstRow!);
+
+    expect(setHoveredRowGroupMock).toHaveBeenCalledWith(null);
+  });
+
+  it('calls setHoveredRowGroup with null on mouse leave on the first row', () => {
+    setup();
+
+    const noteRow = screen.getByTestId('note-row');
+    fireEvent.mouseLeave(noteRow!);
+
+    expect(setHoveredRowGroupMock).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/TableRowWithNote/TableRowWithNote.tsx
+++ b/src/components/TableRowWithNote/TableRowWithNote.tsx
@@ -1,6 +1,6 @@
-import { Table } from 'components/Table/Table';
-import React from 'react';
 import cn from 'utils/cn';
+import React from 'react';
+import { Table } from 'components/Table/Table';
 
 export type TableRowWithNoteProps = {
   rowId: string;
@@ -22,22 +22,21 @@ function TableRowWithNote({
   return (
     <React.Fragment key={rowId}>
       <Table.Row
-          key={rowId}
-          data-state={dataState}
-          data-row-key={rowId}
-          className={cn(
-          "border-b-0",
-          hoveredRowGroup === rowId && 'bg-table-row-hover',
-          )}
-          onMouseEnter={() => setHoveredRowGroup(rowId)}
-          onMouseLeave={() => setHoveredRowGroup(null)}
-      >
-          {...cells}
-      </Table.Row>
-      <Table.Row 
+        key={rowId}
+        data-state={dataState}
+        data-row-key={rowId}
         className={cn(
-            hoveredRowGroup === rowId && 'bg-table-row-hover',
+          'border-b-0',
+          hoveredRowGroup === rowId && 'bg-table-row-hover',
         )}
+        onMouseEnter={() => setHoveredRowGroup(rowId)}
+        onMouseLeave={() => setHoveredRowGroup(null)}
+      >
+        {...cells}
+      </Table.Row>
+      <Table.Row
+        data-testid="note-row"
+        className={cn(hoveredRowGroup === rowId && 'bg-table-row-hover')}
         onMouseEnter={() => setHoveredRowGroup(rowId)}
         onMouseLeave={() => setHoveredRowGroup(null)}
       >

--- a/src/components/TableRowWithNote/TableRowWithNote.tsx
+++ b/src/components/TableRowWithNote/TableRowWithNote.tsx
@@ -1,0 +1,50 @@
+import { Table } from 'components/Table/Table';
+import React from 'react';
+import cn from 'utils/cn';
+
+export type TableRowWithNoteProps = {
+  rowId: string;
+  cells: React.ReactNode[];
+  note: React.ReactNode;
+  dataState: string;
+  hoveredRowGroup: string | null;
+  setHoveredRowGroup: (id: string | null) => void;
+};
+
+function TableRowWithNote({
+  rowId,
+  cells,
+  note,
+  dataState,
+  hoveredRowGroup,
+  setHoveredRowGroup,
+}: TableRowWithNoteProps) {
+  return (
+    <React.Fragment key={rowId}>
+      <Table.Row
+          key={rowId}
+          data-state={dataState}
+          data-row-key={rowId}
+          className={cn(
+          "border-b-0",
+          hoveredRowGroup === rowId && 'bg-table-row-hover',
+          )}
+          onMouseEnter={() => setHoveredRowGroup(rowId)}
+          onMouseLeave={() => setHoveredRowGroup(null)}
+      >
+          {...cells}
+      </Table.Row>
+      <Table.Row 
+        className={cn(
+            hoveredRowGroup === rowId && 'bg-table-row-hover',
+        )}
+        onMouseEnter={() => setHoveredRowGroup(rowId)}
+        onMouseLeave={() => setHoveredRowGroup(null)}
+      >
+        {note}
+      </Table.Row>
+    </React.Fragment>
+  );
+}
+
+export default TableRowWithNote;

--- a/src/components/TableRowWithNote/index.ts
+++ b/src/components/TableRowWithNote/index.ts
@@ -1,0 +1,3 @@
+import TableRowWithNote from './TableRowWithNote';
+
+export default TableRowWithNote;

--- a/src/components/VerticalProgress/VerticalProgress.test.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.test.tsx
@@ -82,4 +82,36 @@ describe('The VerticalProgress component', () => {
       );
     });
   });
+
+  describe('when the status prop is passed', () => {
+    it('sets the color to red when status is CRITICAL', () => {
+      setup({
+        status: 'CRITICAL',
+      });
+
+      const numberOfFilled =
+        (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;
+
+      const wrapper = screen.getByTestId('vertical-progress');
+
+      expect(wrapper.getElementsByClassName('bg-red-400')).toHaveLength(
+        numberOfFilled,
+      );
+    });
+
+    it('sets the color to amber when status is WARNING', () => {
+      setup({
+        status: 'WARNING',
+      });
+
+      const numberOfFilled =
+        (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;
+
+      const wrapper = screen.getByTestId('vertical-progress');
+
+      expect(wrapper.getElementsByClassName('bg-amber-400')).toHaveLength(
+        numberOfFilled,
+      );
+    });
+  });
 });

--- a/src/components/VerticalProgress/VerticalProgress.test.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.test.tsx
@@ -85,9 +85,7 @@ describe('The VerticalProgress component', () => {
 
   describe('when the status prop is passed', () => {
     it('sets the color to red when status is CRITICAL', () => {
-      setup({
-        status: 'CRITICAL',
-      });
+      setup({ status: 'CRITICAL' });
 
       const numberOfFilled =
         (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;
@@ -100,9 +98,7 @@ describe('The VerticalProgress component', () => {
     });
 
     it('sets the color to amber when status is WARNING', () => {
-      setup({
-        status: 'WARNING',
-      });
+      setup({ status: 'WARNING' });
 
       const numberOfFilled =
         (defaultProps.current / defaultProps.max) * VERTICAL_PROGRESS_BARS;

--- a/src/components/VerticalProgress/VerticalProgress.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.tsx
@@ -1,4 +1,4 @@
-import { NodeStatus } from "types/cratedb";
+import { NodeStatus } from 'types/cratedb';
 
 export type VerticalProgressProps = {
   max: number;

--- a/src/components/VerticalProgress/VerticalProgress.tsx
+++ b/src/components/VerticalProgress/VerticalProgress.tsx
@@ -1,12 +1,15 @@
+import { NodeStatus } from "types/cratedb";
+
 export type VerticalProgressProps = {
   max: number;
   current: number;
+  status?: NodeStatus;
   testId?: string;
 };
 
 export const VERTICAL_PROGRESS_BARS = 10;
 
-function VerticalProgress({ max, current, testId }: VerticalProgressProps) {
+function VerticalProgress({ max, current, status, testId }: VerticalProgressProps) {
   const normalized = Math.floor(
     (Math.min(current, max) / max) * VERTICAL_PROGRESS_BARS,
   );
@@ -15,6 +18,12 @@ function VerticalProgress({ max, current, testId }: VerticalProgressProps) {
       ? new Array(VERTICAL_PROGRESS_BARS - normalized).fill('')
       : [];
   const filled = new Array(normalized).fill('');
+  let fillColor = 'bg-crate-blue';
+  if (status === 'CRITICAL') {
+    fillColor = 'bg-red-400';
+  } else if (status === 'WARNING') {
+    fillColor = 'bg-amber-400';
+  }
 
   return (
     <div className="h-full" data-testid={testId}>
@@ -30,7 +39,7 @@ function VerticalProgress({ max, current, testId }: VerticalProgressProps) {
         return (
           <div
             key={`${index}_filled`}
-            className="mb-0.5 h-[4px] w-full bg-crate-blue"
+            className={`mb-0.5 h-[4px] w-full ${fillColor}`}
           ></div>
         );
       })}

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -24,5 +24,11 @@ export const CRATEDB_PRIVILEGES_DOCS =
 export const CRATEDB_ERROR_CODES_DOCS =
   'https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#error-codes';
 
+export const CRATEDB_CLUSTER_DOCS =
+  'https://cratedb.com/docs/crate/reference/en/latest/config/cluster.html';
+export const CRATEDB_CLUSTER_DISK_DOCS = `${CRATEDB_CLUSTER_DOCS}#disk-based-shard-allocation`;
+export const CRATEDB_CLUSTER_HEAP_DOCS =
+  'https://cratedb.com/docs/guide/admin/going-into-production.html#prod-config-heap';
+
 // SQL Editor
 export const SQL_EDITOR_QUERIES_QUOTA = 100;

--- a/src/routes/Nodes/NodesMetrics.test.tsx
+++ b/src/routes/Nodes/NodesMetrics.test.tsx
@@ -4,9 +4,9 @@ import prettyBytes from 'pretty-bytes';
 import { formatNum } from 'utils';
 import { VERTICAL_PROGRESS_BARS } from 'components/VerticalProgress/VerticalProgress';
 import { useClusterNodeStatusMock } from 'test/__mocks__/useClusterNodeStatusMock';
+import { render, screen, within } from '../../../test/testUtils';
 import { useShardsMock } from 'test/__mocks__/useShardsMock';
 import useClusterHealthStore from 'src/state/clusterHealth';
-import { render, screen } from '../../../test/testUtils';
 import { clusterNode } from 'test/__mocks__/nodes';
 import { postFetch } from 'src/swr/jwt/useShards';
 import { QueryResultSuccess } from 'types/query';
@@ -321,6 +321,59 @@ describe('The Nodes component', () => {
         filled,
       );
     });
+
+    it('shows the heap progress bar in yellow if status is warning', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(warningNode);
+          }
+        }),
+      );
+      setup();
+      await waitForTableRender();
+
+      const max = warningNode.rows[0][3].max;
+      const current = warningNode.rows[0][3].used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+      expect(screen.getByTestId('heap-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('heap-progress');
+      expect(verticalProgress.getElementsByClassName('bg-amber-400')).toHaveLength(
+        filled,
+      );
+      server.restoreHandlers();
+    });
+
+    it('shows the heap progress bar in red if status is critical', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(criticalNode);
+          }
+        }),
+      );
+      setup();
+
+      await waitForTableRender();
+
+      const max = criticalNode.rows[0][3].max;
+      const current = criticalNode.rows[0][3].used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+      expect(screen.getByTestId('heap-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('heap-progress');
+      expect(verticalProgress.getElementsByClassName('bg-red-400')).toHaveLength(
+        filled,
+      );
+      server.restoreHandlers();
+    });
   });
 
   describe('the "Disk" cell', () => {
@@ -370,6 +423,59 @@ describe('The Nodes component', () => {
       expect(verticalProgress.getElementsByClassName('bg-crate-blue')).toHaveLength(
         filled,
       );
+    });
+
+    it('shows the disk progress bar in yellow if status is warning', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(warningNode);
+          }
+        }),
+      );
+      setup();
+      await waitForTableRender();
+
+      const max = warningNode.rows[0][4].total.size;
+      const current = warningNode.rows[0][4].total.used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+      expect(screen.getByTestId('disk-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('disk-progress');
+      expect(verticalProgress.getElementsByClassName('bg-amber-400')).toHaveLength(
+        filled,
+      );
+      server.restoreHandlers();
+    });
+
+    it('shows the heap progress bar in red if status is critical', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(criticalNode);
+          }
+        }),
+      );
+      setup();
+
+      await waitForTableRender();
+
+      const max = criticalNode.rows[0][4].total.size;
+      const current = criticalNode.rows[0][4].total.used;
+      const filled = Math.floor((current / max) * VERTICAL_PROGRESS_BARS);
+      expect(screen.getByTestId('disk-progress')).toBeInTheDocument();
+
+      const verticalProgress = screen.getByTestId('disk-progress');
+      expect(verticalProgress.getElementsByClassName('bg-red-400')).toHaveLength(
+        filled,
+      );
+      server.restoreHandlers();
     });
   });
 
@@ -497,6 +603,74 @@ describe('The Nodes component', () => {
       expect(screen.getByTestId('relocating-shards')).toHaveTextContent(
         relocatingShards.toString(),
       );
+    });
+  });
+
+  describe('the "Error Messages" cell', () => {
+    it('shows the error messages if the status is critical', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(criticalNode);
+          }
+        }),
+      );
+
+      setup();
+
+      await waitForTableRender();
+
+      const noteRow = screen.queryByTestId('note-row');
+      expect(noteRow).toBeInTheDocument();
+      expect(
+        within(noteRow!).getByText(
+          'The node is running out of heap memory. Please check the node heap usage.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(noteRow!).getByText(
+          'The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the warning messages if the status is warning', async () => {
+      server.use(
+        http.post('http://localhost:4200/_sql', ({ request }) => {
+          const url = new URL(request.url);
+          const ident = url.searchParams.get('ident');
+
+          if (ident === '/use-cluster-node-status/undefined') {
+            return HttpResponse.json(warningNode);
+          }
+        }),
+      );
+
+      setup();
+
+      await waitForTableRender();
+
+      const noteRow = screen.queryByTestId('note-row');
+      expect(noteRow).toBeInTheDocument();
+      expect(
+        within(noteRow!).getByText(
+          'The node is running low on heap memory. Please check the node heap usage.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(noteRow!).getByText(
+          'The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the error messages row if there are no error messages', async () => {
+      setup();
+      await waitForTableRender();
+      expect(screen.queryByTestId('note-row')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/routes/Nodes/NodesMetrics.tsx
+++ b/src/routes/Nodes/NodesMetrics.tsx
@@ -1,5 +1,10 @@
+import {
+  formatNum,
+  getNodeHealth as setNodeHealth,
+  getNodeStatus,
+  formatBytes,
+} from 'utils';
 import { ColumnDef } from '@tanstack/react-table';
-import { formatNum, getNodeHealth as setNodeHealth, getNodeStatus, formatBytes } from 'utils';
 import prettyBytes from 'pretty-bytes';
 import {
   Chip,
@@ -271,10 +276,10 @@ function NodesMetrics() {
           <Text>Write rate</Text>
         </div>
         <div className="col-span-3">
-          <Text>{formatNum(stats.iops_read, 0, " iops")}</Text>
-          <Text>{formatNum(stats.iops_write, 0, " iops")}</Text>
-          <Text>{formatBytes(stats.bps_read, 2, "/s")}</Text>
-          <Text>{formatBytes(stats.bps_write, 2, "/s")}</Text>
+          <Text>{formatNum(stats.iops_read, 0, ' iops')}</Text>
+          <Text>{formatNum(stats.iops_write, 0, ' iops')}</Text>
+          <Text>{formatBytes(stats.bps_read, 2, '/s')}</Text>
+          <Text>{formatBytes(stats.bps_write, 2, '/s')}</Text>
         </div>
       </div>
     );
@@ -320,7 +325,13 @@ function NodesMetrics() {
   if (!nodes || !cluster || !shards) {
     return <Loader />;
   }
-  return <DataTable columns={columns} data={nodesWithMessages(nodes)!} disablePagination />;
+  return (
+    <DataTable
+      columns={columns}
+      data={nodesWithMessages(nodes)!}
+      disablePagination
+    />
+  );
 }
 
 export default NodesMetrics;

--- a/src/routes/Nodes/NodesMetrics.tsx
+++ b/src/routes/Nodes/NodesMetrics.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { formatNum, getNodeStatus } from 'utils';
+import { formatNum, getNodeHealth as setNodeHealth, getNodeStatus, formatBytes } from 'utils';
 import prettyBytes from 'pretty-bytes';
 import {
   Chip,
@@ -24,6 +24,12 @@ function NodesMetrics() {
   const { data: nodes } = useClusterNodeStatus(clusterId);
   const { data: cluster } = useClusterInfo(clusterId);
   const { data: shards } = useShards(clusterId);
+
+  const nodesWithMessages = (nodes: NodeStatusInfo[]) => {
+    return nodes.map(node => {
+      return setNodeHealth(node);
+    });
+  };
 
   const columns: ColumnDef<NodeStatusInfo>[] = [
     {
@@ -181,6 +187,7 @@ function NodesMetrics() {
           <VerticalProgress
             max={node.heap.max}
             current={node.heap.used}
+            status={node.heap_status}
             testId="heap-progress"
           />
         </div>
@@ -231,6 +238,7 @@ function NodesMetrics() {
           <VerticalProgress
             max={node.fs.total.size}
             current={node.fs.total.used}
+            status={node.fs_status}
             testId="disk-progress"
           />
         </div>
@@ -263,25 +271,10 @@ function NodesMetrics() {
           <Text>Write rate</Text>
         </div>
         <div className="col-span-3">
-          <Text>{formatNum(stats.iops_read, 0)} iops</Text>
-          <Text>{formatNum(stats.iops_write, 0)} iops</Text>
-          <Text>
-            {prettyBytes(clusterHealth[clusterId || '']?.fsStats[node.id].bps_read, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-            /s
-          </Text>
-          <Text>
-            {prettyBytes(
-              clusterHealth[clusterId || '']?.fsStats[node.id].bps_write,
-              {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              },
-            )}
-            /s
-          </Text>
+          <Text>{formatNum(stats.iops_read, 0, " iops")}</Text>
+          <Text>{formatNum(stats.iops_write, 0, " iops")}</Text>
+          <Text>{formatBytes(stats.bps_read, 2, "/s")}</Text>
+          <Text>{formatBytes(stats.bps_write, 2, "/s")}</Text>
         </div>
       </div>
     );
@@ -327,7 +320,7 @@ function NodesMetrics() {
   if (!nodes || !cluster || !shards) {
     return <Loader />;
   }
-  return <DataTable columns={columns} data={nodes!} disablePagination />;
+  return <DataTable columns={columns} data={nodesWithMessages(nodes)!} disablePagination />;
 }
 
 export default NodesMetrics;

--- a/src/routes/Nodes/NodesMetrics.tsx
+++ b/src/routes/Nodes/NodesMetrics.tsx
@@ -1,9 +1,4 @@
-import {
-  formatNum,
-  getNodeHealth as setNodeHealth,
-  getNodeStatus,
-  formatBytes,
-} from 'utils';
+import { formatNum, setNodeHealth, getNodeStatus, formatBytes } from 'utils';
 import { ColumnDef } from '@tanstack/react-table';
 import prettyBytes from 'pretty-bytes';
 import {

--- a/src/routes/Nodes/NodesMetrics.tsx
+++ b/src/routes/Nodes/NodesMetrics.tsx
@@ -27,7 +27,7 @@ function NodesMetrics() {
 
   const nodesWithMessages = (nodes: NodeStatusInfo[]) => {
     return nodes.map(node => {
-      return setNodeHealth(node);
+      return setNodeHealth(node, cluster?.settings);
     });
   };
 

--- a/src/routes/Overview/Overview.tsx
+++ b/src/routes/Overview/Overview.tsx
@@ -70,7 +70,7 @@ function Overview() {
             suffix={
               clusterStatus.primaryRecordAvailabilityPercent < 100 && (
                 <span className="text-red-400">
-                  ({formatNum(clusterStatus.primaryRecordAvailabilityPercent)}%)
+                  ({formatNum(clusterStatus.primaryRecordAvailabilityPercent, 2, "%")})
                 </span>
               )
             }
@@ -83,7 +83,7 @@ function Overview() {
             suffix={
               clusterStatus.primaryShardAvailabilityPercent < 100 && (
                 <span className="text-red-400">
-                  ({formatNum(clusterStatus.primaryShardAvailabilityPercent)}%)
+                  ({formatNum(clusterStatus.primaryShardAvailabilityPercent, 2, "%")})
                 </span>
               )
             }
@@ -96,7 +96,7 @@ function Overview() {
             suffix={
               clusterStatus.replicaAvailabilityPercent < 100 && (
                 <span className="text-amber-400">
-                  ({formatNum(clusterStatus.replicaAvailabilityPercent)}%)
+                  ({formatNum(clusterStatus.replicaAvailabilityPercent, 2, "%")})
                 </span>
               )
             }

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -62,6 +62,7 @@ export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'GOOD';
 export type ErrorMessage = {
   status: NodeStatus;
   message: string;
+  docs_link?: string;
 };
 
 export type NodeStatusInfo = {

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -86,6 +86,19 @@ export type NodeStatusInfo = {
 
 export type ClusterSettings = {
   gateway: { expected_data_nodes: number };
+  cluster?: {
+    routing?: {
+      allocation?: {
+        disk?: {
+          watermark?: {
+            low?: string;
+            high?: string;
+            flood_stage?: string;
+          };
+        };
+      };
+    };
+  };
 };
 
 export type ClusterInfo = {

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -59,7 +59,7 @@ export type MemInfo = {
 
 export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'GOOD';
 
-export type NodeErrorMessage = {
+export type ErrorMessage = {
   status: NodeStatus;
   message: string;
 };
@@ -81,7 +81,7 @@ export type NodeStatusInfo = {
   timestamp: number;
   mem: MemInfo;
   attributes: { [key: string]: string };
-  errorMessages?: NodeErrorMessage[];
+  errorMessages?: ErrorMessage[];
 };
 
 export type ClusterSettings = {

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -59,12 +59,19 @@ export type MemInfo = {
 
 export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'GOOD';
 
+export type NodeErrorMessage = {
+  status: NodeStatus;
+  message: string;
+};
+
 export type NodeStatusInfo = {
   id: string;
   name: string;
   hostname: string;
   heap: HeapUsage;
+  heap_status?: NodeStatus;
   fs: FSInfo;
+  fs_status?: NodeStatus;
   load: LoadAverage;
   version: NodeStatusInfoVersion;
   crate_cpu_usage: number;
@@ -74,6 +81,7 @@ export type NodeStatusInfo = {
   timestamp: number;
   mem: MemInfo;
   attributes: { [key: string]: string };
+  errorMessages?: NodeErrorMessage[];
 };
 
 export type ClusterSettings = {

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,9 +1,14 @@
 import { NODE_STATUS_THRESHOLD } from 'constants/database';
-import { NodeStatus, NodeStatusInfo } from 'types/cratedb';
+import { NodeStatus, NodeStatusInfo, NodeErrorMessage } from 'types/cratedb';
 
-export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
+function getUsedPercent(node: NodeStatusInfo): { fs: number; heap: number } {
   const fs_used_percent = (node.fs.total.used * 100) / node.fs.total.size;
   const heap_used_percent = (node.heap.used * 100) / node.heap.max;
+  return { fs: fs_used_percent, heap: heap_used_percent };
+}
+
+export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
+  const { fs: fs_used_percent, heap: heap_used_percent } = getUsedPercent(node);
 
   if (fs_used_percent === 0 && heap_used_percent === 0) {
     return 'UNREACHABLE';
@@ -18,4 +23,57 @@ export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
       return 'GOOD';
     }
   }
+}
+
+export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
+  const { fs: fs_used_percent, heap: heap_used_percent } = getUsedPercent(node);
+
+  const errorMessages: NodeErrorMessage[] = [];
+
+  if (fs_used_percent === 0) {
+    node.fs_status = 'UNREACHABLE';
+  }
+  else if (fs_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
+    node.fs_status = 'CRITICAL';
+    const msg = `The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.`;
+    const errorMessage: NodeErrorMessage = {
+      status: 'CRITICAL',
+      message: msg,
+    };
+    errorMessages.push(errorMessage);
+  } else if (fs_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
+    node.fs_status = 'WARNING';
+    const msg = `The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.`;
+    const errorMessage: NodeErrorMessage = {
+      status: 'WARNING',
+      message: msg,
+    };
+    errorMessages.push(errorMessage);
+  }
+
+  if (heap_used_percent === 0) {
+    node.heap_status = 'UNREACHABLE';
+  }
+  else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
+    node.heap_status = 'CRITICAL';
+    const msg = `The node is running out of heap memory. Please check the node heap usage.`;
+    const errorMessage: NodeErrorMessage = {
+      status: 'CRITICAL',
+      message: msg,
+    };
+    errorMessages.push(errorMessage);
+  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
+    node.heap_status = 'WARNING';
+    const msg = `The node is running low on heap memory. Please check the node heap usage.`;
+    const errorMessage: NodeErrorMessage = {
+      status: 'WARNING',
+      message: msg,
+    };
+    errorMessages.push(errorMessage);
+  }
+  if (errorMessages.length > 0) {
+    node['errorMessages'] = errorMessages;
+  }
+
+  return node;
 }

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,5 +1,5 @@
 import { NODE_STATUS_THRESHOLD } from 'constants/database';
-import { NodeStatus, NodeStatusInfo, NodeErrorMessage } from 'types/cratedb';
+import { NodeStatus, NodeStatusInfo, ErrorMessage } from 'types/cratedb';
 
 function getUsedPercent(node: NodeStatusInfo): { fs: number; heap: number } {
   const fs_used_percent = (node.fs.total.used * 100) / node.fs.total.size;
@@ -28,7 +28,7 @@ export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
 export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   const { fs: fs_used_percent, heap: heap_used_percent } = getUsedPercent(node);
 
-  const errorMessages: NodeErrorMessage[] = [];
+  const errorMessages: ErrorMessage[] = [];
 
   if (fs_used_percent === 0) {
     node.fs_status = 'UNREACHABLE';
@@ -36,7 +36,7 @@ export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   else if (fs_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
     node.fs_status = 'CRITICAL';
     const msg = `The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.`;
-    const errorMessage: NodeErrorMessage = {
+    const errorMessage: ErrorMessage = {
       status: 'CRITICAL',
       message: msg,
     };
@@ -44,7 +44,7 @@ export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   } else if (fs_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
     node.fs_status = 'WARNING';
     const msg = `The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.`;
-    const errorMessage: NodeErrorMessage = {
+    const errorMessage: ErrorMessage = {
       status: 'WARNING',
       message: msg,
     };
@@ -57,7 +57,7 @@ export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
     node.heap_status = 'CRITICAL';
     const msg = `The node is running out of heap memory. Please check the node heap usage.`;
-    const errorMessage: NodeErrorMessage = {
+    const errorMessage: ErrorMessage = {
       status: 'CRITICAL',
       message: msg,
     };
@@ -65,7 +65,7 @@ export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   } else if (heap_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
     node.heap_status = 'WARNING';
     const msg = `The node is running low on heap memory. Please check the node heap usage.`;
-    const errorMessage: NodeErrorMessage = {
+    const errorMessage: ErrorMessage = {
       status: 'WARNING',
       message: msg,
     };

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -30,7 +30,7 @@ function getUsedPercent(node: NodeStatusInfo): { fs: number; heap: number } {
   return { fs: fs_used_percent, heap: heap_used_percent };
 }
 
-function getThreasholdFromSettings(
+function getThresholdFromSettings(
   watermark: string | undefined,
   defaultValue: number,
 ): number {
@@ -94,12 +94,12 @@ function setDiskHealth(
   fs_used_percent: number,
   settings?: ClusterSettings,
 ) {
-  const criticalDiskThreshold = getThreasholdFromSettings(
+  const criticalDiskThreshold = getThresholdFromSettings(
     settings?.cluster?.routing?.allocation?.disk?.watermark?.flood_stage,
     NODE_STATUS_THRESHOLD.CRITICAL,
   );
 
-  const warningDiskThreshold = getThreasholdFromSettings(
+  const warningDiskThreshold = getThresholdFromSettings(
     settings?.cluster?.routing?.allocation?.disk?.watermark?.high,
     NODE_STATUS_THRESHOLD.WARNING,
   );

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -25,15 +25,14 @@ export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
   }
 }
 
-export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
+export function setNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
   const { fs: fs_used_percent, heap: heap_used_percent } = getUsedPercent(node);
 
   const errorMessages: ErrorMessage[] = [];
 
   if (fs_used_percent === 0) {
     node.fs_status = 'UNREACHABLE';
-  }
-  else if (fs_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
+  } else if (fs_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
     node.fs_status = 'CRITICAL';
     const msg = `The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.`;
     const errorMessage: ErrorMessage = {
@@ -53,8 +52,7 @@ export function getNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
 
   if (heap_used_percent === 0) {
     node.heap_status = 'UNREACHABLE';
-  }
-  else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
+  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
     node.heap_status = 'CRITICAL';
     const msg = `The node is running out of heap memory. Please check the node heap usage.`;
     const errorMessage: ErrorMessage = {

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,3 +1,7 @@
+import {
+  CRATEDB_CLUSTER_HEAP_DOCS,
+  CRATEDB_CLUSTER_DISK_DOCS,
+} from 'constants/defaults';
 import { NODE_STATUS_THRESHOLD } from 'constants/database';
 import {
   NodeStatus,
@@ -42,12 +46,16 @@ function pushErrorMessage(
   errorMessages: ErrorMessage[],
   messageMap: Record<NodeStatus, string>,
   status: NodeStatus,
+  docsLink?: string,
 ) {
   if (status === 'CRITICAL' || status === 'WARNING') {
     const errorMessage: ErrorMessage = {
       status: status,
       message: messageMap[status],
     };
+    if (docsLink) {
+      errorMessage.docs_link = docsLink;
+    }
     errorMessages.push(errorMessage);
   }
 }
@@ -85,7 +93,12 @@ function setHeapHealth(
   }
 
   node.heap_status = heapStatus;
-  pushErrorMessage(errorMessages, HeapStatusMessages, heapStatus);
+  pushErrorMessage(
+    errorMessages,
+    HeapStatusMessages,
+    heapStatus,
+    CRATEDB_CLUSTER_HEAP_DOCS,
+  );
 }
 
 function setDiskHealth(
@@ -114,7 +127,12 @@ function setDiskHealth(
   }
 
   node.fs_status = diskStatus;
-  pushErrorMessage(errorMessages, DiskStatusMessages, diskStatus);
+  pushErrorMessage(
+    errorMessages,
+    DiskStatusMessages,
+    diskStatus,
+    CRATEDB_CLUSTER_DISK_DOCS,
+  );
 }
 
 export function setNodeHealth(

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,10 +1,55 @@
 import { NODE_STATUS_THRESHOLD } from 'constants/database';
-import { NodeStatus, NodeStatusInfo, ErrorMessage } from 'types/cratedb';
+import {
+  NodeStatus,
+  NodeStatusInfo,
+  ErrorMessage,
+  ClusterSettings,
+} from 'types/cratedb';
+
+const DiskStatusMessages: Record<NodeStatus, string> = {
+  CRITICAL:
+    'The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.',
+  WARNING:
+    'The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.',
+  GOOD: '',
+  UNREACHABLE: '',
+};
+
+const HeapStatusMessages: Record<NodeStatus, string> = {
+  CRITICAL:
+    'The node is running out of heap memory. Please check the node heap usage.',
+  WARNING:
+    'The node is running low on heap memory. Please check the node heap usage.',
+  GOOD: '',
+  UNREACHABLE: '',
+};
 
 function getUsedPercent(node: NodeStatusInfo): { fs: number; heap: number } {
   const fs_used_percent = (node.fs.total.used * 100) / node.fs.total.size;
   const heap_used_percent = (node.heap.used * 100) / node.heap.max;
   return { fs: fs_used_percent, heap: heap_used_percent };
+}
+
+function getThreasholdFromSettings(
+  watermark: string | undefined,
+  defaultValue: number,
+): number {
+  const match = watermark?.match(/\d+/);
+  return match ? Number(match[0]) : defaultValue;
+}
+
+function pushErrorMessage(
+  errorMessages: ErrorMessage[],
+  messageMap: Record<NodeStatus, string>,
+  status: NodeStatus,
+) {
+  if (status === 'CRITICAL' || status === 'WARNING') {
+    const errorMessage: ErrorMessage = {
+      status: status,
+      message: messageMap[status],
+    };
+    errorMessages.push(errorMessage);
+  }
 }
 
 export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
@@ -25,50 +70,65 @@ export function getNodeStatus(node: NodeStatusInfo): NodeStatus {
   }
 }
 
-export function setNodeHealth(node: NodeStatusInfo): NodeStatusInfo {
+function setHeapHealth(
+  node: NodeStatusInfo,
+  errorMessages: ErrorMessage[],
+  heap_used_percent: number,
+) {
+  let heapStatus: NodeStatus = 'GOOD';
+  if (heap_used_percent === 0) {
+    heapStatus = 'UNREACHABLE';
+  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
+    heapStatus = 'CRITICAL';
+  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
+    heapStatus = 'WARNING';
+  }
+
+  node.heap_status = heapStatus;
+  pushErrorMessage(errorMessages, HeapStatusMessages, heapStatus);
+}
+
+function setDiskHealth(
+  node: NodeStatusInfo,
+  errorMessages: ErrorMessage[],
+  fs_used_percent: number,
+  settings?: ClusterSettings,
+) {
+  const criticalDiskThreshold = getThreasholdFromSettings(
+    settings?.cluster?.routing?.allocation?.disk?.watermark?.flood_stage,
+    NODE_STATUS_THRESHOLD.CRITICAL,
+  );
+
+  const warningDiskThreshold = getThreasholdFromSettings(
+    settings?.cluster?.routing?.allocation?.disk?.watermark?.high,
+    NODE_STATUS_THRESHOLD.WARNING,
+  );
+
+  let diskStatus: NodeStatus = 'GOOD';
+  if (fs_used_percent === 0) {
+    diskStatus = 'UNREACHABLE';
+  } else if (fs_used_percent > criticalDiskThreshold) {
+    diskStatus = 'CRITICAL';
+  } else if (fs_used_percent > warningDiskThreshold) {
+    diskStatus = 'WARNING';
+  }
+
+  node.fs_status = diskStatus;
+  pushErrorMessage(errorMessages, DiskStatusMessages, diskStatus);
+}
+
+export function setNodeHealth(
+  node: NodeStatusInfo,
+  settings?: ClusterSettings,
+): NodeStatusInfo {
   const { fs: fs_used_percent, heap: heap_used_percent } = getUsedPercent(node);
 
   const errorMessages: ErrorMessage[] = [];
 
-  if (fs_used_percent === 0) {
-    node.fs_status = 'UNREACHABLE';
-  } else if (fs_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
-    node.fs_status = 'CRITICAL';
-    const msg = `The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.`;
-    const errorMessage: ErrorMessage = {
-      status: 'CRITICAL',
-      message: msg,
-    };
-    errorMessages.push(errorMessage);
-  } else if (fs_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
-    node.fs_status = 'WARNING';
-    const msg = `The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.`;
-    const errorMessage: ErrorMessage = {
-      status: 'WARNING',
-      message: msg,
-    };
-    errorMessages.push(errorMessage);
-  }
+  setDiskHealth(node, errorMessages, fs_used_percent, settings);
+  setHeapHealth(node, errorMessages, heap_used_percent);
 
-  if (heap_used_percent === 0) {
-    node.heap_status = 'UNREACHABLE';
-  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.CRITICAL) {
-    node.heap_status = 'CRITICAL';
-    const msg = `The node is running out of heap memory. Please check the node heap usage.`;
-    const errorMessage: ErrorMessage = {
-      status: 'CRITICAL',
-      message: msg,
-    };
-    errorMessages.push(errorMessage);
-  } else if (heap_used_percent > NODE_STATUS_THRESHOLD.WARNING) {
-    node.heap_status = 'WARNING';
-    const msg = `The node is running low on heap memory. Please check the node heap usage.`;
-    const errorMessage: ErrorMessage = {
-      status: 'WARNING',
-      message: msg,
-    };
-    errorMessages.push(errorMessage);
-  }
+  // Add error messages to node if there are any
   if (errorMessages.length > 0) {
     node['errorMessages'] = errorMessages;
   }

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,11 +1,13 @@
-export function formatNum(num: number | undefined, digits = 2) {
+import prettyBytes from "pretty-bytes";
+
+export function formatNum(num: number | undefined, digits = 2, suffix = '') {
   if (num == undefined || isNaN(num)) {
     return;
   }
   return num.toLocaleString('en', {
     maximumFractionDigits: digits,
     minimumFractionDigits: digits,
-  });
+  }) + suffix;
 }
 
 export function formatHumanReadable(num: number | undefined) {
@@ -16,4 +18,14 @@ export function formatHumanReadable(num: number | undefined) {
     notation: 'compact',
     unitDisplay: 'narrow',
   }).format(num);
+}
+
+export function formatBytes(num: number | undefined, digits = 2, suffix = '') {
+  if (num == undefined || isNaN(num)) {
+    return;
+  }
+  return prettyBytes(num, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }) + suffix;
 }


### PR DESCRIPTION
## Summary of changes

- Updated VerticalProgress component to have a color code based on the metric status
- Added a new component TableRowWithNote that creates 2 tables rows that behave like one
- Added an error message to the node row when the heap usage or disk usage is high, with a link to the documentation
- Use disk watermark from CrateDB cluster settings
- Fix some warnings in the tests
- Added formatBytes in utils to make sure that it doesn't return errors when the value is NaN

<img width="2559" height="881" alt="image" src="https://github.com/user-attachments/assets/1d03dd89-e22d-4389-b993-9b56367c975a" />


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2734
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
