### PR TITLE
Change SQL editor auto-complete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changed SQL editor auto-complete to use prefix matching and require at least
+  2 characters before showing suggestions.
+
 ## 2026-03-31 - 0.23.3
 
 - Add error messages related to node status.

--- a/src/components/SQLEditor/SQLEditor.tsx
+++ b/src/components/SQLEditor/SQLEditor.tsx
@@ -22,6 +22,7 @@ import { annotate } from './annotationUtils';
 import { useSchemaTree } from 'src/swr/jwt';
 import { QueryStatus } from 'types/query';
 import { Button } from 'components';
+import { crateDbCompleter } from './cratedbCompleter';
 import './mode-cratedb';
 
 export type SQLEditorProps = {
@@ -358,6 +359,7 @@ function SQLEditor({
               onChange={onValueChange}
               mode="cratedb"
               onLoad={editor => {
+                editor.completers = [crateDbCompleter];
                 setAce(editor);
               }}
               scrollMargin={[5, 5, 0, 5]}

--- a/src/components/SQLEditor/cratedbCompleter.test.tsx
+++ b/src/components/SQLEditor/cratedbCompleter.test.tsx
@@ -1,14 +1,14 @@
-import { Completion } from 'ace-builds-internal/autocomplete';
+import { Ace } from 'ace-builds';
 import { crateDbCompleter } from './cratedbCompleter';
 
-const getCompletions = (prefix: string): Promise<Completion[]> => {
+const getCompletions = (prefix: string): Promise<Ace.Completion[]> => {
   return new Promise(resolve => {
     crateDbCompleter.getCompletions(
-      {} as any,
-      {} as any,
+      {} as Ace.Editor,
+      {} as Ace.EditSession,
       { row: 0, column: 0 },
       prefix,
-      (_err, completions: Completion[]) => resolve(completions),
+      (_err, completions: Ace.Completion[]) => resolve(completions),
     );
   });
 };
@@ -47,7 +47,7 @@ describe('crateDbCompleter', () => {
     expect(sha1).toBeUndefined();
   });
 
-  it('matches functions in lowercase', async () => {
+  it('matches functions', async () => {
     const results = await getCompletions('array_a');
     expect(results).toEqual(
       expect.arrayContaining([
@@ -57,7 +57,7 @@ describe('crateDbCompleter', () => {
     );
   });
 
-  it('matches data types in uppercase', async () => {
+  it('matches data types', async () => {
     const results = await getCompletions('varc');
     expect(results).toEqual([
       { caption: 'varchar', meta: 'type', score: 800, value: 'varchar' },

--- a/src/components/SQLEditor/cratedbCompleter.test.tsx
+++ b/src/components/SQLEditor/cratedbCompleter.test.tsx
@@ -1,0 +1,72 @@
+import { Completion } from 'ace-builds-internal/autocomplete';
+import { crateDbCompleter } from './cratedbCompleter';
+
+const getCompletions = (prefix: string): Promise<Completion[]> => {
+  return new Promise(resolve => {
+    crateDbCompleter.getCompletions(
+      {} as any,
+      {} as any,
+      { row: 0, column: 0 },
+      prefix,
+      (_err, completions: Completion[]) => resolve(completions),
+    );
+  });
+};
+
+describe('crateDbCompleter', () => {
+  it('returns no suggestions for empty prefix', async () => {
+    const results = await getCompletions('');
+    expect(results).toEqual([]);
+  });
+
+  it('returns no suggestions for single character', async () => {
+    const results = await getCompletions('s');
+    expect(results).toEqual([]);
+  });
+
+  it('returns no suggestions for digit prefix', async () => {
+    const results = await getCompletions('1');
+    expect(results).toEqual([]);
+  });
+
+  it('returns no suggestions for multi-digit prefix', async () => {
+    const results = await getCompletions('123');
+    expect(results).toEqual([]);
+  });
+
+  it('returns matching keywords for prefix with 2+ characters', async () => {
+    const results = await getCompletions('sele');
+    expect(results).toEqual([
+      { caption: 'select', meta: 'keyword', score: 1000, value: 'select' },
+    ]);
+  });
+
+  it('does prefix matching only, not substring', async () => {
+    const results = await getCompletions('ha1');
+    const sha1 = results.find(c => c.value === 'sha1');
+    expect(sha1).toBeUndefined();
+  });
+
+  it('matches functions in lowercase', async () => {
+    const results = await getCompletions('array_a');
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: 'array_agg', meta: 'function' }),
+        expect.objectContaining({ value: 'array_append', meta: 'function' }),
+      ]),
+    );
+  });
+
+  it('matches data types in uppercase', async () => {
+    const results = await getCompletions('varc');
+    expect(results).toEqual([
+      { caption: 'varchar', meta: 'type', score: 800, value: 'varchar' },
+    ]);
+  });
+
+  it('is case-insensitive', async () => {
+    const lower = await getCompletions('sel');
+    const upper = await getCompletions('SEL');
+    expect(lower).toEqual(upper);
+  });
+});

--- a/src/components/SQLEditor/cratedbCompleter.test.tsx
+++ b/src/components/SQLEditor/cratedbCompleter.test.tsx
@@ -41,6 +41,11 @@ describe('crateDbCompleter', () => {
     ]);
   });
 
+  it("returns no suggestions if there's no match", async () => {
+    const results = await getCompletions('zzz');
+    expect(results).toEqual([]);
+  });
+
   it('does prefix matching only, not substring', async () => {
     const results = await getCompletions('ha1');
     const sha1 = results.find(c => c.value === 'sha1');

--- a/src/components/SQLEditor/cratedbCompleter.tsx
+++ b/src/components/SQLEditor/cratedbCompleter.tsx
@@ -5,20 +5,17 @@ import {
 } from '../../constants/cratedbEditorKeywords';
 import type { Ace } from 'ace-builds';
 
-type Completion = {
-  caption: string;
-  value: string;
-  score: number;
-  meta: string;
-};
-
-function buildCompletions(list: string, meta: string, score: number): Completion[] {
+function buildCompletions(
+  list: string,
+  meta: string,
+  score: number,
+): Ace.Completion[] {
   return list.split('|').map(word => {
     return { caption: word, value: word, score, meta };
   });
 }
 
-const allCompletions: Completion[] = [
+const allCompletions: Ace.Completion[] = [
   ...buildCompletions(keywords, 'keyword', 1000),
   ...buildCompletions(builtinFunctions, 'function', 900),
   ...buildCompletions(dataTypes, 'type', 800),
@@ -28,9 +25,9 @@ export const crateDbCompleter: Ace.Completer = {
   getCompletions(
     _editor: Ace.Editor,
     _session: Ace.EditSession,
-    _pos: Ace.Point,
+    _position: Ace.Point,
     prefix: string,
-    callback: (err: null, completions: Completion[]) => void,
+    callback: Ace.CompleterCallback,
   ): void {
     if (!prefix || prefix.length < 2 || /^\d/.test(prefix)) {
       callback(null, []);
@@ -38,7 +35,7 @@ export const crateDbCompleter: Ace.Completer = {
     }
     const lower = prefix.toLowerCase();
     const filtered = allCompletions.filter(c =>
-      c.value.toLowerCase().startsWith(lower),
+      c.value?.toLowerCase().startsWith(lower),
     );
     callback(null, filtered);
   },

--- a/src/components/SQLEditor/cratedbCompleter.tsx
+++ b/src/components/SQLEditor/cratedbCompleter.tsx
@@ -1,0 +1,45 @@
+import {
+  builtinFunctions,
+  dataTypes,
+  keywords,
+} from '../../constants/cratedbEditorKeywords';
+import type { Ace } from 'ace-builds';
+
+type Completion = {
+  caption: string;
+  value: string;
+  score: number;
+  meta: string;
+};
+
+function buildCompletions(list: string, meta: string, score: number): Completion[] {
+  return list.split('|').map(word => {
+    return { caption: word, value: word, score, meta };
+  });
+}
+
+const allCompletions: Completion[] = [
+  ...buildCompletions(keywords, 'keyword', 1000),
+  ...buildCompletions(builtinFunctions, 'function', 900),
+  ...buildCompletions(dataTypes, 'type', 800),
+];
+
+export const crateDbCompleter: Ace.Completer = {
+  getCompletions(
+    _editor: Ace.Editor,
+    _session: Ace.EditSession,
+    _pos: Ace.Point,
+    prefix: string,
+    callback: (err: null, completions: Completion[]) => void,
+  ): void {
+    if (!prefix || prefix.length < 2 || /^\d/.test(prefix)) {
+      callback(null, []);
+      return;
+    }
+    const lower = prefix.toLowerCase();
+    const filtered = allCompletions.filter(c =>
+      c.value.toLowerCase().startsWith(lower),
+    );
+    callback(null, filtered);
+  },
+};

--- a/src/components/SQLEditor/mode-cratedb.js
+++ b/src/components/SQLEditor/mode-cratedb.js
@@ -1,3 +1,9 @@
+import {
+  builtinFunctions,
+  dataTypes,
+  keywords,
+} from '../../constants/cratedbEditorKeywords';
+
 // try / catch to prevent tests failing
 // i've wasted a lot of time on trying to get this to work without success
 // this works fine in the app, and we can improve it in future if we get chance to
@@ -10,56 +16,7 @@ try {
       var oop = require('../lib/oop');
       var TextHighlightRules = require('./text_highlight_rules').TextHighlightRules;
       var SqlHighlightRules = function () {
-        // select word from pg_get_keywords() order by word;
-        var keywords =
-          'absolute|add|alias|all|allocate|alter|always|analyze|analyzer|and|any|array|artifacts|' +
-          'as|asc|asensitive|at|authorization|backward|begin|bernoulli|between|binary|blob|boolean|' +
-          'both|by|byte|called|cancel|case|cast|catalogs|char_filters|character|characteristics|' +
-          'check|close|cluster|clustered|column|columns|commit|committed|conflict|connection|' +
-          'constraint|copy|costs|create|cross|current|current_date|current_schema|current_time|' +
-          'current_timestamp|current_user|cursor|dangling|day|deallocate|declare|decommission|' +
-          'default|deferrable|delete|deny|desc|describe|directory|disable|discard|distinct|' +
-          'distributed|do|double|drop|duplicate|dynamic|else|enable|end|escape|except|exists|' +
-          'explain|extends|extract|failed|false|fetch|filter|first|float|following|for|format|' +
-          'forward|from|full|fulltext|function|functions|gc|generated|geo_point|geo_shape|global|' +
-          'grant|graphviz|group|having|hold|hour|if|ignore|ignored|ilike|in|index|inner|input|' +
-          'insensitive|insert|int|integer|intersect|interval|into|ip|is|isolation|join|key|kill|' +
-          'language|last|leading|left|level|like|limit|local|logical|long|match|materialized|' +
-          'metadata|minute|month|move|natural|next|no|not|nothing|null|nulls|object|off|offset|' +
-          'on|only|open|optimize|or|order|outer|over|partition|partitioned|partitions|persistent|' +
-          'plain|plans|preceding|precision|prepare|prior|privileges|promote|publication|range|' +
-          'read|recursive|refresh|relative|rename|repeatable|replace|replica|repository|reroute|' +
-          'reset|respect|restore|retry|return|returning|returns|revoke|right|row|rows|schema|' +
-          'schemas|scroll|second|select|sequences|serializable|session|session_user|set|shard|' +
-          'shards|short|show|snapshot|some|start|storage|stratify|strict|string|subscription|' +
-          'substring|summary|swap|system|table|tables|tablesample|temp|temporary|text|then|' +
-          'time|timestamp|to|token_filters|tokenizer|trailing|transaction|transaction_isolation|' +
-          'transient|trim|true|try_cast|type|unbounded|uncommitted|union|update|user|using|' +
-          'values|varying|view|when|where|window|with|without|work|write|year|zone';
         var builtinConstants = 'true|false';
-        var builtinFunctions =
-          'abs|acos|age|any_value|arbitrary|area|array|array_agg|array_append|array_avg|array_cat|' +
-          'array_difference|array_length|array_lower|array_max|array_min|array_position|array_set|' +
-          'array_slice|array_sum|array_to_string|array_unique|array_unnest|array_upper|ascii|asin|atan|' +
-          'atan2|avg|bit_length|btrim|ceil|ceiling|char_length|chr|coalesce|col_description|concat|' +
-          'concat_ws|cos|cot|count|curdate|current_database|current_date|current_schema|current_schemas|' +
-          'current_setting|current_time|current_timestamp|current_user|date_bin|date_format|date_trunc|' +
-          'decode|degrees|dense_rank|distance|empty_row|encode|exp|extract|first_value|floor|format|' +
-          'format_type|gen_random_text_uuid|geohash|geometric_mean|greatest|has_database_privilege|' +
-          'has_schema_privilege|hyperloglog_distinct|if|ignore3vl|in|information_schema._pg_expandarray|' +
-          'initcap|intersects|knn_match|lag|last_value|latitude|lead|least|left|length|ln|log|longitude|' +
-          'lower|lpad|ltrim|max|max_by|md5|mean|min|min_by|mod|modulus|now|nth_value|null_or_empty|' +
-          'null_string|nullif|obj_description|object_keys|octet_length|parse_uri|parse_url|percentile|' +
-          'pg_backend_pid|pg_catalog.generate_series|pg_catalog.generate_subscripts|' +
-          'pg_catalog.pg_get_keywords|pg_encoding_to_char|pg_function_is_visible|pg_get_expr|' +
-          'pg_get_function_result|pg_get_partkeydef|pg_get_serial_sequence|pg_get_userbyid|' +
-          'pg_postmaster_start_time|pg_typeof|pi|power|quote_ident|radians|random|rank|regexp_matches|' +
-          'regexp_replace|repeat|replace|right|round|row_number|rpad|rtrim|separator|session_user|sha1|' +
-          'sin|split_part|sqrt|stddev|string_agg|string_to_array|substr|sum|tan|timezone|to_char|' +
-          'translate|trim|trunc|unnest|upper|user|variance|version|within';
-        var dataTypes =
-          'int|numeric|decimal|date|varchar|char|bigint|float|double|bit|binary|text|set|timestamp|' +
-          'money|real|number|integer|string';
         var keywordMapper = this.createKeywordMapper(
           {
             'support.function': builtinFunctions,

--- a/src/constants/cratedbEditorKeywords.ts
+++ b/src/constants/cratedbEditorKeywords.ts
@@ -1,0 +1,53 @@
+// CrateDB SQL keywords, functions, and data types
+
+// select word from pg_get_keywords() order by word;
+export const keywords =
+  'absolute|add|alias|all|allocate|alter|always|analyze|analyzer|and|any|array|artifacts|' +
+  'as|asc|asensitive|at|authorization|backward|begin|bernoulli|between|binary|blob|boolean|' +
+  'both|by|byte|called|cancel|case|cast|catalogs|char_filters|character|characteristics|' +
+  'check|close|cluster|clustered|column|columns|commit|committed|conflict|connection|' +
+  'constraint|copy|costs|create|cross|current|current_date|current_schema|current_time|' +
+  'current_timestamp|current_user|cursor|dangling|day|deallocate|declare|decommission|' +
+  'default|deferrable|delete|deny|desc|describe|directory|disable|discard|distinct|' +
+  'distributed|do|double|drop|duplicate|dynamic|else|enable|end|escape|except|exists|' +
+  'explain|extends|extract|failed|false|fetch|filter|first|float|following|for|format|' +
+  'forward|from|full|fulltext|function|functions|gc|generated|geo_point|geo_shape|global|' +
+  'grant|graphviz|group|having|hold|hour|if|ignore|ignored|ilike|in|index|inner|input|' +
+  'insensitive|insert|int|integer|intersect|interval|into|ip|is|isolation|join|key|kill|' +
+  'language|last|leading|left|level|like|limit|local|logical|long|match|materialized|' +
+  'metadata|minute|month|move|natural|next|no|not|nothing|null|nulls|object|off|offset|' +
+  'on|only|open|optimize|or|order|outer|over|partition|partitioned|partitions|persistent|' +
+  'plain|plans|preceding|precision|prepare|prior|privileges|promote|publication|range|' +
+  'read|recursive|refresh|relative|rename|repeatable|replace|replica|repository|reroute|' +
+  'reset|respect|restore|retry|return|returning|returns|revoke|right|row|rows|schema|' +
+  'schemas|scroll|second|select|sequences|serializable|session|session_user|set|shard|' +
+  'shards|short|show|snapshot|some|start|storage|stratify|strict|string|subscription|' +
+  'substring|summary|swap|system|table|tables|tablesample|temp|temporary|text|then|' +
+  'time|timestamp|to|token_filters|tokenizer|trailing|transaction|transaction_isolation|' +
+  'transient|trim|true|try_cast|type|unbounded|uncommitted|union|update|user|using|' +
+  'values|varying|view|when|where|window|with|without|work|write|year|zone';
+
+export const builtinFunctions =
+  'abs|acos|age|any_value|arbitrary|area|array|array_agg|array_append|array_avg|array_cat|' +
+  'array_difference|array_length|array_lower|array_max|array_min|array_position|array_set|' +
+  'array_slice|array_sum|array_to_string|array_unique|array_unnest|array_upper|ascii|asin|atan|' +
+  'atan2|avg|bit_length|btrim|ceil|ceiling|char_length|chr|coalesce|col_description|concat|' +
+  'concat_ws|cos|cot|count|curdate|current_database|current_date|current_schema|current_schemas|' +
+  'current_setting|current_time|current_timestamp|current_user|date_bin|date_format|date_trunc|' +
+  'decode|degrees|dense_rank|distance|empty_row|encode|exp|extract|first_value|floor|format|' +
+  'format_type|gen_random_text_uuid|geohash|geometric_mean|greatest|has_database_privilege|' +
+  'has_schema_privilege|hyperloglog_distinct|if|ignore3vl|in|information_schema._pg_expandarray|' +
+  'initcap|intersects|knn_match|lag|last_value|latitude|lead|least|left|length|ln|log|longitude|' +
+  'lower|lpad|ltrim|max|max_by|md5|mean|min|min_by|mod|modulus|now|nth_value|null_or_empty|' +
+  'null_string|nullif|obj_description|object_keys|octet_length|parse_uri|parse_url|percentile|' +
+  'pg_backend_pid|pg_catalog.generate_series|pg_catalog.generate_subscripts|' +
+  'pg_catalog.pg_get_keywords|pg_encoding_to_char|pg_function_is_visible|pg_get_expr|' +
+  'pg_get_function_result|pg_get_partkeydef|pg_get_serial_sequence|pg_get_userbyid|' +
+  'pg_postmaster_start_time|pg_typeof|pi|power|quote_ident|radians|random|rank|regexp_matches|' +
+  'regexp_replace|repeat|replace|right|round|row_number|rpad|rtrim|separator|session_user|sha1|' +
+  'sin|split_part|sqrt|stddev|string_agg|string_to_array|substr|sum|tan|timezone|to_char|' +
+  'translate|trim|trunc|unnest|upper|user|variance|version|within';
+
+export const dataTypes =
+  'int|numeric|decimal|date|varchar|char|bigint|float|double|bit|binary|text|set|timestamp|' +
+  'money|real|number|integer|string';


### PR DESCRIPTION
## Summary of changes

I have added a completer to the editor. It skips auto-completion when:
- the prefix is shorter than 2 characters
- the prefix is only digits

It is not case-sensitive.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2320
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
