### PR TITLE
Expose ClusterHealthStore and add disk watermark status to it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Expose ClusterHealthStore and add disk watermark status to it.
+
 ## 2026-04-16 - 0.24.0
 
 - Changed SQL editor auto-complete to use prefix matching and require at least

--- a/src/components/ClusterHealthManager/ClusterHealthManager.test.tsx
+++ b/src/components/ClusterHealthManager/ClusterHealthManager.test.tsx
@@ -1,0 +1,188 @@
+import ClusterHealthManager, {
+  ClusterHealthManagerProps,
+} from './ClusterHealthManager';
+import { useClusterNodeStatusMock } from 'test/__mocks__/useClusterNodeStatusMock';
+import { useClusterInfoMock } from 'test/__mocks__/useClusterInfoMock';
+import server, { customExecuteJWTQueryResponse } from 'test/msw';
+import { act, render, waitFor } from '../../../test/testUtils';
+import useClusterHealthStore from 'state/clusterHealth';
+import { QueryResultSuccess } from 'types/query';
+
+const CLUSTER_ID = 'test-cluster-id';
+const defaultProps: ClusterHealthManagerProps = {
+  clusterId: CLUSTER_ID,
+};
+
+const setup = (props: Partial<ClusterHealthManagerProps> = {}) => {
+  const combinedProps = { ...defaultProps, ...props };
+  return render(<ClusterHealthManager {...combinedProps} />);
+};
+
+const makeNodeRow = (diskUsed: number, diskSize: number) => {
+  const row = JSON.parse(JSON.stringify(useClusterNodeStatusMock.rows[0]));
+  row[4].total.used = diskUsed;
+  row[4].total.size = diskSize;
+  return row;
+};
+
+const mockNodeStatus = (rows: [][]) => {
+  const nodeMock: QueryResultSuccess = { ...useClusterNodeStatusMock, rows };
+  server.use(
+    customExecuteJWTQueryResponse({ '/use-cluster-node-status': nodeMock }),
+  );
+};
+
+describe('ClusterHealthManager', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    act(() => {
+      useClusterHealthStore.setState({ clusterHealth: {} });
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('load', () => {
+    it('populates the store with load data when nodes are available', async () => {
+      setup();
+
+      await waitFor(() => {
+        const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+        expect(health).toBeDefined();
+        expect(health.load.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('stores the averaged load values across all nodes', async () => {
+      setup();
+
+      await waitFor(() => {
+        const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+        const latest = health?.load[health.load.length - 1];
+        expect(latest?.['1']).toBe(8);
+        expect(latest?.['5']).toBe(4);
+        expect(latest?.['15']).toBe(2);
+      });
+    });
+  });
+
+  describe('diskWatermark', () => {
+    describe("disk usage is below the cluster's LOW threshold", () => {
+      beforeEach(() => {
+        mockNodeStatus([makeNodeRow(0, 100)]);
+      });
+
+      it('is null when disk usage is below the LOW threshold', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBeNull();
+        });
+      });
+    });
+
+    describe("disk usage is above the cluster's LOW threshold", () => {
+      beforeEach(() => {
+        mockNodeStatus([makeNodeRow(87, 100)]);
+      });
+
+      it('sets LOW level when disk usage exceeds the LOW threshold (default 85%)', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBe('LOW');
+        });
+      });
+    });
+
+    describe("disk usage is above the cluster's HIGH threshold", () => {
+      beforeEach(() => {
+        mockNodeStatus([makeNodeRow(92, 100)]);
+      });
+
+      it('sets HIGH level when disk usage exceeds the HIGH threshold', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBe('HIGH');
+        });
+      });
+    });
+
+    describe("disk usage is above the cluster's FLOOD_STAGE threshold", () => {
+      beforeEach(() => {
+        mockNodeStatus([makeNodeRow(97, 100)]);
+      });
+
+      it('sets FLOOD_STAGE level when disk usage exceeds the FLOOD_STAGE threshold', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBe('FLOOD_STAGE');
+        });
+      });
+    });
+
+    describe('when the watermark thresholds are coming from cluster settings', () => {
+      beforeEach(() => {
+        const clusterRow = JSON.parse(JSON.stringify(useClusterInfoMock.rows[0]));
+        clusterRow[3].cluster.routing.allocation.disk.watermark = { low: '70%' };
+        const clusterMock: QueryResultSuccess = {
+          ...useClusterInfoMock,
+          rows: [clusterRow],
+        };
+
+        server.use(
+          customExecuteJWTQueryResponse({
+            '/use-cluster-node-status': {
+              ...useClusterNodeStatusMock,
+              rows: [makeNodeRow(75, 100)],
+            },
+            '/use-cluster-info': clusterMock,
+          }),
+        );
+      });
+
+      it('uses custom watermark thresholds from cluster settings', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBe('LOW');
+        });
+      });
+    });
+
+    describe('when two nodes have different disk usage levels', () => {
+      beforeEach(() => {
+        mockNodeStatus([makeNodeRow(97, 100), makeNodeRow(87, 100)]);
+      });
+
+      it('reports the highest watermark level when multiple nodes have different levels', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBe('FLOOD_STAGE');
+        });
+      });
+    });
+
+    describe('when there is no disk size returned', () => {
+      beforeEach(() => {
+        mockNodeStatus([]);
+      });
+      it('is null for nodes with zero disk size', async () => {
+        setup();
+        await waitFor(() => {
+          const health = useClusterHealthStore.getState().clusterHealth[CLUSTER_ID];
+          expect(health?.diskWatermark?.disksWatermarkStatus).toBeUndefined();
+        });
+      });
+    });
+  });
+});

--- a/src/components/ClusterHealthManager/ClusterHealthManager.tsx
+++ b/src/components/ClusterHealthManager/ClusterHealthManager.tsx
@@ -1,8 +1,8 @@
+import { getClusterDiskWatermarkStatus } from 'utils/nodes';
 import { useEffect, useState } from 'react';
 import { FSStats, LoadAverage, NodeStatusInfo } from 'types/cratedb';
-import useClusterHealthStore from 'state/clusterHealth';
 import { useClusterInfo, useClusterNodeStatus } from 'src/swr/jwt';
-import { getClusterDiskWatermarkStatus } from 'utils/nodes';
+import useClusterHealthStore from 'state/clusterHealth';
 
 export type ClusterHealthManagerProps = {
   clusterId: string;

--- a/src/components/ClusterHealthManager/ClusterHealthManager.tsx
+++ b/src/components/ClusterHealthManager/ClusterHealthManager.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { FSStats, LoadAverage, NodeStatusInfo } from 'types/cratedb';
 import useClusterHealthStore from 'state/clusterHealth';
-import { useClusterNodeStatus } from 'src/swr/jwt';
+import { useClusterInfo, useClusterNodeStatus } from 'src/swr/jwt';
+import { getClusterDiskWatermarkStatus } from 'utils/nodes';
 
 export type ClusterHealthManagerProps = {
   clusterId: string;
@@ -12,6 +13,7 @@ export const STATS_PERIOD = 15 * 60 * 1000;
 function ClusterHealthManager({ clusterId }: ClusterHealthManagerProps) {
   const { clusterHealth, setClusterHealth } = useClusterHealthStore();
   const { data: nodes } = useClusterNodeStatus(clusterId);
+  const { data: cluster } = useClusterInfo(clusterId);
   const [prevNodeData, setPrevNodesData] = useState<NodeStatusInfo[] | []>();
 
   const getFs = (nodes: NodeStatusInfo[]): Record<string, FSStats> => {
@@ -74,9 +76,13 @@ function ClusterHealthManager({ clusterId }: ClusterHealthManagerProps) {
       return;
     }
 
-    setClusterHealth(clusterId, { load: getLoad(nodes), fsStats: getFs(nodes) });
+    setClusterHealth(clusterId, {
+      load: getLoad(nodes),
+      fsStats: getFs(nodes),
+      diskWatermark: getClusterDiskWatermarkStatus(nodes, cluster?.settings),
+    });
     setPrevNodesData(nodes);
-  }, [nodes]);
+  }, [nodes, cluster]);
 
   return null;
 }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -76,6 +76,8 @@ const getStatusClass = (status: string) => {
       return 'border-red-400';
     case 'WARNING':
       return 'border-amber-400';
+    case 'INFO':
+      return 'border-gray-200';
     default:
       return '';
   }

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -16,6 +16,13 @@ export const NODE_STATUS_THRESHOLD = {
   GOOD: 0,
 } as const;
 
+export const DISK_WATERMARK_DEFAULT = {
+  FLOOD_STAGE: { value: 95, rank: 3 },
+  HIGH: { value: 90, rank: 2 },
+  LOW: { value: 85, rank: 1 },
+} as const;
+export type DiskWatermarkLevel = keyof typeof DISK_WATERMARK_DEFAULT;
+
 // JWT authentication was added in crate 5.7.2. however, it is supported
 // on all clusters in the cloud from 5.8.2.
 // it is possible to manually enable it on 5.7.2+ cloud clusters, but at

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+import useClusterHealthStore, { ClusterHealthStore } from './state/clusterHealth';
 import useJWTManagerStore, { JWTManagerStore } from './state/jwtManager';
 import './index.css';
 
-export { useJWTManagerStore };
+export { useJWTManagerStore, useClusterHealthStore };
 export * from './components';
 export * from './hooks';
 export * from './routes';
@@ -13,4 +14,4 @@ export * from 'types/query';
 
 export * from 'utils/sqlFormatter';
 
-export type { JWTManagerStore };
+export type { JWTManagerStore, ClusterHealthStore };

--- a/src/state/clusterHealth.ts
+++ b/src/state/clusterHealth.ts
@@ -1,15 +1,17 @@
 // the state in this file is not persisted to localStorage
 // use this for cluster health management only
 
+import { ClusterDisksWatermarkStatus } from 'utils/nodes';
 import { create } from 'zustand';
 import { FSStats, LoadAverage } from 'types/cratedb';
 
 type ClusterHealth = {
   load: LoadAverage[];
   fsStats: { [key: string]: FSStats };
+  diskWatermark?: ClusterDisksWatermarkStatus;
 };
 
-type ClusterHealthStore = {
+export type ClusterHealthStore = {
   clusterHealth: Record<string, ClusterHealth>;
   setClusterHealth: (clusterId: string, health: ClusterHealth) => void;
 };

--- a/src/types/cratedb.ts
+++ b/src/types/cratedb.ts
@@ -57,7 +57,7 @@ export type MemInfo = {
   used: number;
 };
 
-export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'GOOD';
+export type NodeStatus = 'UNREACHABLE' | 'CRITICAL' | 'WARNING' | 'INFO' | 'GOOD';
 
 export type ErrorMessage = {
   status: NodeStatus;

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,8 +1,12 @@
 import {
+  DISK_WATERMARK_DEFAULT,
+  DiskWatermarkLevel,
+  NODE_STATUS_THRESHOLD,
+} from 'constants/database';
+import {
   CRATEDB_CLUSTER_HEAP_DOCS,
   CRATEDB_CLUSTER_DISK_DOCS,
 } from 'constants/defaults';
-import { NODE_STATUS_THRESHOLD } from 'constants/database';
 import {
   NodeStatus,
   NodeStatusInfo,
@@ -15,6 +19,7 @@ const DiskStatusMessages: Record<NodeStatus, string> = {
     'The flood stage disk watermark is exceeded on the node. Tables that reside on an affected disk on this node have been made read-only. Please check the node disk usage.',
   WARNING:
     'The high disk watermark is exceeded on the node. The cluster will attempt to relocate shards to another node. Please check the node disk usage.',
+  INFO: 'The low disk watermark is exceeded on the node. New shards will not be allocated on this node. Please check the node disk usage.',
   GOOD: '',
   UNREACHABLE: '',
 };
@@ -24,6 +29,7 @@ const HeapStatusMessages: Record<NodeStatus, string> = {
     'The node is running out of heap memory. Please check the node heap usage.',
   WARNING:
     'The node is running low on heap memory. Please check the node heap usage.',
+  INFO: '',
   GOOD: '',
   UNREACHABLE: '',
 };
@@ -48,7 +54,7 @@ function pushErrorMessage(
   status: NodeStatus,
   docsLink?: string,
 ) {
-  if (status === 'CRITICAL' || status === 'WARNING') {
+  if (status === 'CRITICAL' || status === 'WARNING' || status === 'INFO') {
     const errorMessage: ErrorMessage = {
       status: status,
       message: messageMap[status],
@@ -101,29 +107,41 @@ function setHeapHealth(
   );
 }
 
+function getDiskThresholds(settings?: ClusterSettings) {
+  return {
+    floodStageDiskThreshold: getThresholdFromSettings(
+      settings?.cluster?.routing?.allocation?.disk?.watermark?.flood_stage,
+      DISK_WATERMARK_DEFAULT.FLOOD_STAGE.value,
+    ),
+    highDiskThreshold: getThresholdFromSettings(
+      settings?.cluster?.routing?.allocation?.disk?.watermark?.high,
+      DISK_WATERMARK_DEFAULT.HIGH.value,
+    ),
+    lowDiskThreshold: getThresholdFromSettings(
+      settings?.cluster?.routing?.allocation?.disk?.watermark?.low,
+      DISK_WATERMARK_DEFAULT.LOW.value,
+    ),
+  };
+}
+
 function setDiskHealth(
   node: NodeStatusInfo,
   errorMessages: ErrorMessage[],
   fs_used_percent: number,
   settings?: ClusterSettings,
 ) {
-  const criticalDiskThreshold = getThresholdFromSettings(
-    settings?.cluster?.routing?.allocation?.disk?.watermark?.flood_stage,
-    NODE_STATUS_THRESHOLD.CRITICAL,
-  );
-
-  const warningDiskThreshold = getThresholdFromSettings(
-    settings?.cluster?.routing?.allocation?.disk?.watermark?.high,
-    NODE_STATUS_THRESHOLD.WARNING,
-  );
+  const { floodStageDiskThreshold, highDiskThreshold, lowDiskThreshold } =
+    getDiskThresholds(settings);
 
   let diskStatus: NodeStatus = 'GOOD';
   if (fs_used_percent === 0) {
     diskStatus = 'UNREACHABLE';
-  } else if (fs_used_percent > criticalDiskThreshold) {
+  } else if (fs_used_percent > floodStageDiskThreshold) {
     diskStatus = 'CRITICAL';
-  } else if (fs_used_percent > warningDiskThreshold) {
+  } else if (fs_used_percent > highDiskThreshold) {
     diskStatus = 'WARNING';
+  } else if (fs_used_percent > lowDiskThreshold) {
+    diskStatus = 'INFO';
   }
 
   node.fs_status = diskStatus;
@@ -152,4 +170,48 @@ export function setNodeHealth(
   }
 
   return node;
+}
+
+export type ClusterDisksWatermarkStatus = {
+  disksWatermarkStatus: DiskWatermarkLevel | null;
+};
+
+export function getClusterDiskWatermarkStatus(
+  nodes: NodeStatusInfo[],
+  settings?: ClusterSettings,
+): ClusterDisksWatermarkStatus {
+  const { floodStageDiskThreshold, highDiskThreshold, lowDiskThreshold } =
+    getDiskThresholds(settings);
+
+  let highestLevel: DiskWatermarkLevel | null = null;
+
+  nodes.forEach(node => {
+    if (node.fs.total.size === 0) {
+      return;
+    }
+    const usedPercent = (node.fs.total.used * 100) / node.fs.total.size;
+
+    let nodeLevel: DiskWatermarkLevel | null = null;
+    if (usedPercent > floodStageDiskThreshold) {
+      nodeLevel = 'FLOOD_STAGE';
+    } else if (usedPercent > highDiskThreshold) {
+      nodeLevel = 'HIGH';
+    } else if (usedPercent > lowDiskThreshold) {
+      nodeLevel = 'LOW';
+    }
+
+    if (nodeLevel) {
+      if (
+        !highestLevel ||
+        DISK_WATERMARK_DEFAULT[nodeLevel].rank >
+          DISK_WATERMARK_DEFAULT[highestLevel].rank
+      ) {
+        highestLevel = nodeLevel;
+      }
+    }
+  });
+
+  return {
+    disksWatermarkStatus: highestLevel,
+  };
 }

--- a/test/msw/handlers/queries.ts
+++ b/test/msw/handlers/queries.ts
@@ -23,42 +23,28 @@ import { useShardsMock } from 'test/__mocks__/useShardsMock';
 import handlerFactory from 'test/msw/handlerFactory';
 
 const getJWTQueryResult = (ident?: string | null): object => {
-  switch (ident) {
-    case '/console-query':
-      return {
-        col_types: [],
-        cols: [],
-        rows: [],
-        rowcount: 0,
-        duration: 123.45,
-      };
-    case '/ddl-table-query':
-      return getTablesDDLQueryResult;
-    case '/ddl-view-query':
-      return getViewsDDLQueryResult;
-    case '/use-allocations':
-      return useAllocationsMock;
-    case '/use-cluster-info':
-      return useClusterInfoMock;
-    case '/use-cluster-node-status':
-      return useClusterNodeStatusMock;
-    case '/use-current-user':
-      return useCurrentUserMock;
-    case '/use-query-stats':
-      return useQueryStatsMock;
-    case '/use-schema-tree':
-      return useSchemaTreeMock;
-    case '/use-shards':
-      return useShardsMock;
-    case '/use-tables':
-      return useTablesMock;
-    case '/use-tables-shards':
-      return useTablesShardsMock;
-    case '/use-users-roles':
-      return useUsersRolesMock;
-    default:
-      return queryResult;
-  }
+  const identMap: Record<string, object> = {
+    '/console-query': {
+      col_types: [],
+      cols: [],
+      rows: [],
+      rowcount: 0,
+      duration: 123.45,
+    },
+    '/ddl-table-query': getTablesDDLQueryResult,
+    '/ddl-view-query': getViewsDDLQueryResult,
+    '/use-allocations': useAllocationsMock,
+    '/use-cluster-info': useClusterInfoMock,
+    '/use-cluster-node-status': useClusterNodeStatusMock,
+    '/use-current-user': useCurrentUserMock,
+    '/use-query-stats': useQueryStatsMock,
+    '/use-schema-tree': useSchemaTreeMock,
+    '/use-shards': useShardsMock,
+    '/use-tables': useTablesMock,
+    '/use-tables-shards': useTablesShardsMock,
+    '/use-users-roles': useUsersRolesMock,
+  };
+  return ident && identMap[ident] ? identMap[ident] : queryResult;
 };
 
 const executeJWTQueryPost = http.post(

--- a/test/msw/handlers/queries.ts
+++ b/test/msw/handlers/queries.ts
@@ -3,7 +3,7 @@ import {
   getTablesDDLQuery,
   getViewsDDLQuery,
 } from 'constants/queries';
-import { http, HttpResponse } from 'msw';
+import { DefaultBodyType, http, HttpResponse } from 'msw';
 import {
   getTablesColumnsResult,
   getTablesDDLQueryResult,
@@ -22,64 +22,51 @@ import { useTablesMock } from 'test/__mocks__/useTablesMock';
 import { useShardsMock } from 'test/__mocks__/useShardsMock';
 import handlerFactory from 'test/msw/handlerFactory';
 
+const getJWTQueryResult = (ident?: string | null): object => {
+  switch (ident) {
+    case '/console-query':
+      return {
+        col_types: [],
+        cols: [],
+        rows: [],
+        rowcount: 0,
+        duration: 123.45,
+      };
+    case '/ddl-table-query':
+      return getTablesDDLQueryResult;
+    case '/ddl-view-query':
+      return getViewsDDLQueryResult;
+    case '/use-allocations':
+      return useAllocationsMock;
+    case '/use-cluster-info':
+      return useClusterInfoMock;
+    case '/use-cluster-node-status':
+      return useClusterNodeStatusMock;
+    case '/use-current-user':
+      return useCurrentUserMock;
+    case '/use-query-stats':
+      return useQueryStatsMock;
+    case '/use-schema-tree':
+      return useSchemaTreeMock;
+    case '/use-shards':
+      return useShardsMock;
+    case '/use-tables':
+      return useTablesMock;
+    case '/use-tables-shards':
+      return useTablesShardsMock;
+    case '/use-users-roles':
+      return useUsersRolesMock;
+    default:
+      return queryResult;
+  }
+};
+
 const executeJWTQueryPost = http.post(
   'http://localhost:4200/_sql',
   async ({ request }) => {
     const url = new URL(request.url);
     const ident = url.searchParams.get('ident')?.split('/').slice(0, 2).join('/');
-    let result: null | object = null;
-
-    switch (ident) {
-      case '/console-query':
-        result = {
-          col_types: [],
-          cols: [],
-          rows: [],
-          rowcount: 0,
-          duration: 123.45,
-        };
-        break;
-      case '/ddl-table-query':
-        result = getTablesDDLQueryResult;
-        break;
-      case '/ddl-view-query':
-        result = getViewsDDLQueryResult;
-        break;
-      case '/use-allocations':
-        result = useAllocationsMock;
-        break;
-      case '/use-cluster-info':
-        result = useClusterInfoMock;
-        break;
-      case '/use-cluster-node-status':
-        result = useClusterNodeStatusMock;
-        break;
-      case '/use-current-user':
-        result = useCurrentUserMock;
-        break;
-      case '/use-query-stats':
-        result = useQueryStatsMock;
-        break;
-      case '/use-schema-tree':
-        result = useSchemaTreeMock;
-        break;
-      case '/use-shards':
-        result = useShardsMock;
-        break;
-      case '/use-tables':
-        result = useTablesMock;
-        break;
-      case '/use-tables-shards':
-        result = useTablesShardsMock;
-        break;
-      case '/use-users-roles':
-        result = useUsersRolesMock;
-        break;
-      default:
-        result = queryResult; // todo
-    }
-
-    return HttpResponse.json(result);
+    return HttpResponse.json(getJWTQueryResult(ident));
   },
 );
 
@@ -105,6 +92,21 @@ const executeQueryPost = http.post('/api/_sql', async ({ request }) => {
 
   return HttpResponse.json(result);
 });
+
+export const customExecuteJWTQueryResponse = (
+  responses: Record<string, DefaultBodyType>,
+) => {
+  return http.post('http://localhost:4200/_sql', async ({ request }) => {
+    const url = new URL(request.url);
+    const ident = url.searchParams.get('ident')?.split('/').slice(0, 2).join('/');
+
+    if (ident && responses[ident] !== undefined) {
+      return HttpResponse.json(responses[ident]);
+    }
+
+    return HttpResponse.json(getJWTQueryResult(ident));
+  });
+};
 
 export const executeJWTQueryHandlers = [executeJWTQueryPost];
 export const executeQueryHandlers = [executeQueryPost];

--- a/test/msw/index.ts
+++ b/test/msw/index.ts
@@ -15,4 +15,7 @@ export {
   customGetPolicyLogs,
   customGetEligibleColumns,
 } from './handlers/policies';
-export { customExecuteQueryResponse } from './handlers/queries';
+export {
+  customExecuteJWTQueryResponse,
+  customExecuteQueryResponse,
+} from './handlers/queries';


### PR DESCRIPTION
## Summary of changes

- It calculates the highest disk watermark all the nodes and expose it through `ClusterHealthStore` that can be used by cloud-ui to display a notification.
- It shows a info note bellow the node row in the cluster monitoring if the low disk watermark is exceeded.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2354
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
