### PR TITLE
fix: restore dist/style.css output after Vite 5→6 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
       "export": "./dist/index.umd.js",
-      "require": "./dist/index.umd.js",
-      "types": "./dist/index.d.ts"
-    },
+      "require": "./dist/index.umd.js"
+   },
     "./style.css": "./dist/style.css"
   },
   "files": [

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -31,6 +31,7 @@ export default defineConfig(() => {
         entry: resolve(__dirname, 'src/index.ts'),
         name: packageJson.name,
         fileName: format => `index.${format}.js`,
+        cssFileName: 'style',
       },
       rollupOptions: {
         input: 'src/index.ts',


### PR DESCRIPTION
## Summary of changes

Vite 6 lib mode derives the CSS output filename from lib.name rather than using the hardcoded 'style.css' from Vite 5. Adding cssFileName: 'style' to the lib config restores the expected output path, keeping the package.json './style.css' export intact.

Moreover, Vite 6 requires that exports are listed in the order to be applied.

## Checklist

- [ ] ~Link to issue this PR refers to:~
- [ ] ~Relevant changes are reflected in `CHANGES.md`.~
- [ ] ~Added or changed code is covered by tests.~
- [ ] ~Required Grand Central APIs are already merged.~
