### PR TITLE
Add ref to Button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Expose ClusterHealthStore and add disk watermark status to it.
+- Added ref to Button
 
 ## 2026-04-16 - 0.24.0
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -35,6 +35,7 @@ export type ButtonProps = {
 };
 
 function Button({
+  ref,
   ariaControls,
   ariaExpanded,
   ariaHasPopup,
@@ -51,7 +52,7 @@ function Button({
   size = BUTTON_SIZES.REGULAR,
   type = BUTTON_INPUT_TYPES.BUTTON,
   warn = false,
-}: ButtonProps) {
+}: React.ComponentPropsWithRef<'button'> & ButtonProps) {
   const buttonClasses = useButtonStyles({
     disabled,
     kind,
@@ -95,7 +96,7 @@ function Button({
   );
 
   return (
-    <button {...buttonProps}>
+    <button {...buttonProps} ref={ref}>
       <span>{children}</span>
       {loading && <Loader className="ml-2" size={Loader.sizes.SMALL} />}
     </button>


### PR DESCRIPTION
## Summary of changes

I've added ref support to Button so overlay components like Popconfirm can reliably attach to and position themselves against the real DOM button element, especially after React 19 timing/lifecycle changes.

Without it, Popconfirm may briefly lose its anchor and appear in the wrong place.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2930
- [x] Relevant changes are reflected in `CHANGES.md`.
- [ ] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
