### PR TITLE
Handle NotAllowedError in CopyToClipboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Prevent unfocused document bug happening in CopyToClipboard component.
+
 ## 2026-05-04 - 0.24.1
 
 - Expose ClusterHealthStore and add disk watermark status to it.

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -20,12 +20,19 @@ function CopyToClipboard({
   return (
     <button
       data-testid={testId}
-      onClick={() => {
-        navigator.clipboard.writeText(textToCopy);
-        showSuccessMessage(successMessage);
-
-        if (additionalClickHandler) {
-          additionalClickHandler();
+      onClick={async () => {
+        // We very occasionally see a `NotAllowedError` exception when the document is not focused.
+        // The try/catch block is a workaround to handle this gracefully, but it happens so infrequently
+        // it is not worth the effort required to handle it better.
+        try {
+          if (!document.hasFocus()) {
+            window.focus();
+          }
+          await navigator.clipboard.writeText(textToCopy);
+          showSuccessMessage(successMessage);
+          additionalClickHandler?.();
+        } catch {
+          //
         }
       }}
       type="button"


### PR DESCRIPTION
## Summary of changes
Safely handle the `NotAllowedError` in the CopyToClipboard component. This bug happens incredibly rarely, so I don't feel it is worthwhile to fix it "properly" with complex fallback options. Instead, just make it fail silently.

## `Checklist`

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2674
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [x] Required Grand Central APIs are already merged.