### PR TITLE
Warning color more yellow than red

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 2026-05-19 - 0.24.2
+
+- Make the warning colour more yellow than red.
 - Fix bug where the error trace data was not scrollable and flowed off-screen.
 - Prevent unfocused document bug happening in CopyToClipboard component.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/routes/TablesShards/TablesShardsMetrics.tsx
+++ b/src/routes/TablesShards/TablesShardsMetrics.tsx
@@ -111,8 +111,8 @@ function TablesShardsMetrics() {
               );
             case 'YELLOW':
               return (
-                <div className="flex items-center gap-2 text-orange-600">
-                  <div className="h-2 w-2 rounded-full bg-orange-600" />
+                <div className="flex items-center gap-2 text-amber-600">
+                  <div className="h-2 w-2 rounded-full bg-amber-600" />
                   <span>{TABLE_HEALTH_DESCRIPTIONS.YELLOW}</span>
                 </div>
               );


### PR DESCRIPTION
## Summary of changes
Make the warning colour more yellow than red

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2735
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] Required Grand Central APIs are already merged.
