### PR TITLE
Table policy form warning firing incorrectly fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,18 +2,23 @@
 
 ## Unreleased
 
+## 2026-05-27 - 0.25.2
+
+- Fix issue with table policy warning firing to eagerly.
+- Add minimum release age to pnpm config.
+
 ## 2026-05-26 - 0.25.1
 
 - Update node and pnpm versions.
 
 ## 2026-05-22 - 0.25.0
 
-- Migrate from yarn to pnpms
-- Dependabot: Bump react-intl from 7.1.11 to 7.1.14
-- Dependabot: Bump flatted from 3.3.1 to 3.4.2
-- Dependabot: Bump ws from 8.18.0 to 8.20.1
-- Dependabot: Bump fast-uri from 3.0.3 to 3.1.2
-- Dependabot: Bump nginx from 1.29.7 to 1.29.8
+- Migrate from yarn to pnpm.
+- Dependabot: Bump react-intl from 7.1.11 to 7.1.14.
+- Dependabot: Bump flatted from 3.3.1 to 3.4.2.
+- Dependabot: Bump ws from 8.18.0 to 8.20.1.
+- Dependabot: Bump fast-uri from 3.0.3 to 3.1.2.
+- Dependabot: Bump nginx from 1.29.7 to 1.29.8.
 
 ## 2026-05-19 - 0.24.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cratedb/crate-gc-admin",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "author": "cratedb",
   "private": false,
   "type": "module",

--- a/src/routes/Automation/hooks/useEligibleColumns.ts
+++ b/src/routes/Automation/hooks/useEligibleColumns.ts
@@ -64,9 +64,13 @@ export default function useEligibleColumns({
     // Update eligible columns if targets changes
     if (targets.length === 0) {
       setEligibleColumns([]);
-    } else {
-      setLoadingColumns(true);
-      getEligibleColumns(gcApi, targets).then(columns => {
+      setLoadingColumns(false);
+      return;
+    }
+
+    setLoadingColumns(true);
+    getEligibleColumns(gcApi, targets)
+      .then(columns => {
         if (columns !== null) {
           const eligibleColumns = Object.keys(columns.eligible_columns).map(
             columnName => {
@@ -81,9 +85,10 @@ export default function useEligibleColumns({
         } else {
           setEligibleColumns([]);
         }
+      })
+      .finally(() => {
+        setLoadingColumns(false);
       });
-    }
-    setLoadingColumns(false);
   }, [targets]);
 
   useEffect(() => {
@@ -133,7 +138,7 @@ export default function useEligibleColumns({
       });
 
     setShowColumnsWarning(!isValid);
-  }, [tables, targets, columnName, loadingColumns]);
+  }, [tables, targets, columnName, loadingColumns, eligibleColumns]);
 
   return {
     eligibleColumns,


### PR DESCRIPTION
## Summary of changes
This problem was caused by two related bugs:
- some synchronous code was firing during some async code execution, despite relying on the result of the async output. 
- a useEffect was missing a required value causing it not to fire certain cases

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2678
- [x] Relevant changes are reflected in `CHANGES.md`.
- [x] Added or changed code is covered by tests.
- [ ] ~~Required Grand Central APIs are already merged.~~
