### PR TITLE
Set min. release age to five days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ ignoreScripts: true
 overrides:
   '@types/react@*': 19.0.0
   '@types/react-dom@*': 19.0.0
+
+minimumReleaseAge: 7200


### PR DESCRIPTION
## Summary of changes

In pnpm v11 the default value is one day (1440 minutes), and I propose that we set it to five days (7200 minutes) to be more save.

## Checklist

- [ ] ~Link to issue this PR refers to:~
- [ ] ~Relevant changes are reflected in `CHANGES.md`.~
- [ ] ~Added or changed code is covered by tests.~
- [ ] ~Required Grand Central APIs are already merged.~
